### PR TITLE
Remove unused job_id

### DIFF
--- a/supervisor/mock/src/main.rs
+++ b/supervisor/mock/src/main.rs
@@ -173,7 +173,6 @@ impl connector::Supervisor for MockSupervisor {
         // stopped first:
         if jobs_lg.get(&msg.job_id).is_some() {
             return Err(connector::JobError {
-                job_id: msg.job_id,
                 request_id: Some(msg.request_id),
                 error_kind: connector::JobErrorKind::AlreadyRunning,
                 description: format!(
@@ -186,7 +185,6 @@ impl connector::Supervisor for MockSupervisor {
         // Don't start more jobs than we're allowed to:
         if jobs_lg.len() > this.config.mock.max_parallel_jobs {
             return Err(connector::JobError {
-                job_id: msg.job_id,
                 request_id: Some(msg.request_id),
                 error_kind: connector::JobErrorKind::MaxConcurrentJobs,
                 description: format!(
@@ -295,7 +293,6 @@ impl connector::Supervisor for MockSupervisor {
                 .get(&msg.job_id)
                 .cloned()
                 .ok_or(connector::JobError {
-                    job_id: msg.job_id,
                     request_id: Some(msg.request_id),
                     error_kind: connector::JobErrorKind::JobNotFound,
                     description: format!("Job {:?} not found, cannot stop.", msg.job_id),
@@ -333,7 +330,6 @@ impl connector::Supervisor for MockSupervisor {
                 *job_lg = prev_state;
 
                 return Err(connector::JobError {
-                    job_id: msg.job_id,
                     request_id: Some(msg.request_id),
                     error_kind: connector::JobErrorKind::AlreadyStopping,
                     description: format!("Job {:?} is already stopping.", msg.job_id),

--- a/treadmill-rs/src/connector.rs
+++ b/treadmill-rs/src/connector.rs
@@ -35,7 +35,6 @@ pub enum JobErrorKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobError {
-    pub job_id: Uuid,
     pub request_id: Option<Uuid>,
     pub error_kind: JobErrorKind,
     pub description: String,


### PR DESCRIPTION
The `job_id` is passed outside of the `JobError` struct (such as through the HTTP endpoint to which the `JobError` struct is posted).