### PR TITLE
Add rust-analyzer to toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-components = [ "rustfmt" ]
+components = [ "rustfmt", "rust-analyzer" ]
 profile = "minimal"


### PR DESCRIPTION
Useful to keep the Rust Analyzer version in sync with our toolchain configuration.