### PR TITLE
Forward job parameters from Coordinator via Supervisor to Puppet

### DIFF
--- a/puppet/src/control_socket_client.rs
+++ b/puppet/src/control_socket_client.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{bail, Context, Result};
 
 // TCP control socket transport implementation:
@@ -5,7 +7,7 @@ use anyhow::{bail, Context, Result};
 pub use tml_tcp_control_socket_client as tcp;
 
 use treadmill_rs::api::supervisor_puppet::{
-    NetworkConfig, PuppetEvent, PuppetReq, SupervisorEvent, SupervisorResp,
+    NetworkConfig, ParameterValue, PuppetEvent, PuppetReq, SupervisorEvent, SupervisorResp,
 };
 
 pub enum ControlSocketClient {
@@ -70,6 +72,23 @@ impl ControlSocketClient {
             _ => {
                 bail!(
                     "Invalid supervisor response to network config request: {:?}",
+                    resp
+                );
+            }
+        }
+    }
+
+    pub async fn get_parameters(&self) -> Result<HashMap<String, ParameterValue>> {
+        let resp = self
+            .request(PuppetReq::Parameters)
+            .await
+            .context("Sending parameters request to supervisor")?;
+
+        match resp {
+            SupervisorResp::Parameters { parameters } => Ok(parameters),
+            _ => {
+                bail!(
+                    "Invalid supervisor response to parameters request: {:?}",
                     resp
                 );
             }

--- a/treadmill-rs/src/api/supervisor_puppet.rs
+++ b/treadmill-rs/src/api/supervisor_puppet.rs
@@ -1,7 +1,11 @@
 //! Types used in the interface between supervisors and the puppet
 //! daemon running on hosts.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+
+pub use super::switchboard_supervisor::ParameterValue;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -11,6 +15,7 @@ pub enum PuppetReq {
     Ping,
     SSHKeys,
     NetworkConfig,
+    Parameters,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -178,8 +183,13 @@ pub struct NetworkConfig {
 pub enum SupervisorResp {
     // Request reponses:
     PingResp,
-    SSHKeysResp { ssh_keys: Vec<String> },
+    SSHKeysResp {
+        ssh_keys: Vec<String>,
+    },
     NetworkConfig(NetworkConfig),
+    Parameters {
+        parameters: HashMap<String, ParameterValue>,
+    },
 
     // Error responses:
     UnsupportedRequest,

--- a/treadmill-rs/src/api/switchboard_supervisor.rs
+++ b/treadmill-rs/src/api/switchboard_supervisor.rs
@@ -105,7 +105,7 @@ pub enum JobState {
     },
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ParameterValue {
     pub value: String,
     pub secret: bool,

--- a/treadmill-rs/src/control_socket.rs
+++ b/treadmill-rs/src/control_socket.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use uuid::Uuid;
 
@@ -37,4 +39,17 @@ pub trait Supervisor: Send + Sync + 'static {
     /// the host's hostname, and may optionally provide IPv4 and IPv6 addresses,
     /// gateways, and a DNS server.
     async fn network_config(&self, job_id: Uuid) -> Option<supervisor_puppet::NetworkConfig>;
+
+    /// Puppet job parameters request.
+    ///
+    /// If the supervisor deems that this job is currently active, it should
+    /// respond with the full set of parameters supplied by the coordinator.
+    ///
+    /// Returning `None` implies that this job id is currently not active. If a
+    /// job has no parameters defined, the `parameters` field should be an empty
+    /// `HashMap`.
+    async fn parameters(
+        &self,
+        job_id: Uuid,
+    ) -> Option<HashMap<String, supervisor_puppet::ParameterValue>>;
 }


### PR DESCRIPTION
This commit loops the job parameters HashMap through from the initial start job request to the supervisor, and then allows the puppet daemon to retrieve it. This daemon in turn can create a directory that exposes the contents of this map as a set of files.