### PR TITLE
image_generator/Ubuntu-Image: Added ability to create custom Ubuntu images

### DIFF
--- a/treadmill-rs/src/image/image_generator/README.md
+++ b/treadmill-rs/src/image/image_generator/README.md
@@ -1,0 +1,59 @@
+# Building and Running a Custom Ubuntu VM Image with Nix
+
+## Prerequisites
+
+Ensure you have the following files in your working directory:
+
+- `ubuntu-image.nix`
+- `default.nix`
+- `run-ubuntu-vm.nix`
+
+Please make sure to replace `YOUR_PUBLIC_SSH_KEY` with your public ssh key
+
+## Steps
+
+1. Build the Ubuntu image:
+
+   ```bash
+   nix-build
+   ```
+
+2. Copy the image out of the Nix store:
+
+   ```bash
+   cp result/disk-image.qcow2 ~/ubuntu-image.qcow2
+   ```
+
+3. Set appropriate permissions on the image file:
+
+   ```bash
+   chmod 644 ~/ubuntu-image.qcow2
+   ```
+
+4. Build the VM runner script:
+
+   ```bash
+   nix-build run-ubuntu-vm.nix
+   ```
+
+5. Run the VM:
+
+   ```bash
+   ./result/bin/run-ubuntu-vm ~/ubuntu-image.qcow2
+   ```
+
+6. Once the VM boots, you'll see a login prompt. Log in as root with the password "root".
+
+7. To SSH into the VM from another terminal window:
+   ```bash
+   ssh -p 2222 root@localhost
+   ```
+   Use the password "root" when prompted.
+
+## Additional Notes
+
+- To modify the image, edit `ubuntu-image.nix` and repeat steps 1-3.
+- To change VM runtime parameters, edit `run-ubuntu-vm.nix` and repeat steps 4-5.
+- Remember to copy the image out of the Nix store and reset permissions after each rebuild.
+- For security, change the root password after first login.
+- Update or remove the SSH key in `ubuntu-image.nix` before sharing the image.

--- a/treadmill-rs/src/image/image_generator/default.nix
+++ b/treadmill-rs/src/image/image_generator/default.nix
@@ -1,0 +1,2 @@
+{pkgs ? import <nixpkgs> {}}:
+pkgs.callPackage ./ubuntu-image.nix {}

--- a/treadmill-rs/src/image/image_generator/run-ubuntu-vm.nix
+++ b/treadmill-rs/src/image/image_generator/run-ubuntu-vm.nix
@@ -1,0 +1,33 @@
+with import <nixpkgs> {}; let
+  ovmf = pkgs.OVMF.fd;
+in
+  stdenv.mkDerivation {
+    name = "run-ubuntu-vm";
+    buildInputs = [pkgs.qemu];
+
+    unpackPhase = "true";
+
+    installPhase = ''
+      mkdir -p $out/bin $out/share
+      cp ${ovmf}/FV/OVMF_VARS.fd $out/share/OVMF_VARS.fd
+      cat > $out/bin/run-ubuntu-vm <<EOF
+      #!/bin/sh
+      IMAGE_PATH=\''${1:-\$HOME/ubuntu-image.qcow2}
+      VARS_FILE=\''${XDG_DATA_HOME:-\$HOME/.local/share}/qemu/OVMF_VARS.fd
+      mkdir -p \$(dirname \$VARS_FILE)
+      if [ ! -f \$VARS_FILE ]; then
+        cp $out/share/OVMF_VARS.fd \$VARS_FILE
+      fi
+      exec ${pkgs.qemu}/bin/qemu-system-x86_64 \\
+        -m 2G \\
+        -smp 2 \\
+        -drive if=pflash,format=raw,readonly=on,file=${ovmf}/FV/OVMF_CODE.fd \\
+        -drive if=pflash,format=raw,file="\$VARS_FILE" \\
+        -drive file="\$IMAGE_PATH",if=virtio \\
+        -net nic,model=virtio \\
+        -net user,hostfwd=tcp::2222-:22 \\
+        -nographic
+      EOF
+      chmod +x $out/bin/run-ubuntu-vm
+    '';
+  }

--- a/treadmill-rs/src/image/image_generator/ubuntu-image.nix
+++ b/treadmill-rs/src/image/image_generator/ubuntu-image.nix
@@ -160,30 +160,6 @@
         ${coreutils}/bin/mkdir -p $out/dev-image-store/images/''${IMAGE_HASH:0:2}/''${IMAGE_HASH:2:2}/''${IMAGE_HASH:4:2}
         ${coreutils}/bin/mv $out/dev-image-store/image_manifest.toml $out/dev-image-store/images/''${IMAGE_HASH:0:2}/''${IMAGE_HASH:2:2}/''${IMAGE_HASH:4:2}/$IMAGE_HASH
 
-        # Create the manifest.toml file in the root of dev-image-store
-        ${coreutils}/bin/cat > $out/dev-image-store/manifest.toml << EOF
-        manifest_version = "0.0"
-        manifest_extensions = [ "org.tockos.treadmill.manifest-ext.base" ]
-
-        "org.tockos.treadmill.manifest-ext.base.label" = "Ubuntu 20.04 base installation"
-        "org.tockos.treadmill.manifest-ext.base.revision" = 0
-        "org.tockos.treadmill.manifest-ext.base.description" = '''
-        Base Ubuntu 20.04 installation, without any customizations.
-        Minimal packages selected, DHCP network configuration.
-        Credentials: root / root
-        '''
-
-        ["org.tockos.treadmill.manifest-ext.base.attrs"]
-        "org.tockos.treadmill.image.qemu_layered_v0.head" = "layer-0"
-
-        ["org.tockos.treadmill.manifest-ext.base.blobs".layer-0]
-        "org.tockos.treadmill.manifest-ext.base.sha256-digest" = "$BLOB_HASH"
-        "org.tockos.treadmill.manifest-ext.base.size" = $(${coreutils}/bin/stat -c%s ${ubuntuImage}/disk-image.qcow2)
-
-        ["org.tockos.treadmill.manifest-ext.base.blobs".layer-0."org.tockos.treadmill.manifest-ext.base.attrs"]
-        "org.tockos.treadmill.image.qemu_layered_v0.blob-virtual-size" = 5368709120
-        EOF
-
         # Verify the directory structure
         ${tree}/bin/tree $out/dev-image-store/
 

--- a/treadmill-rs/src/image/image_generator/ubuntu-image.nix
+++ b/treadmill-rs/src/image/image_generator/ubuntu-image.nix
@@ -103,7 +103,7 @@ vmTools.makeImageFromDebDist {
     # CONFIG
     # Place your public binary here
     # For example:
-    # cp ./custom_binary /usr/local/bin/
+    # cp /path/to/custom_binary /usr/local/bin/
     # chmod +x /usr/local/bin/custom_binary
     CHROOT
 

--- a/treadmill-rs/src/image/image_generator/ubuntu-image.nix
+++ b/treadmill-rs/src/image/image_generator/ubuntu-image.nix
@@ -7,110 +7,192 @@
   dosfstools,
   e2fsprogs,
   systemd,
-}:
-vmTools.makeImageFromDebDist {
-  inherit (vmTools.debDistros.ubuntu2004x86_64) name fullName urlPrefix packagesLists;
-  packages =
-    lib.filter (p:
-      !lib.elem p [
-        "g++"
-        "make"
-        "dpkg-dev"
-        "pkg-config"
-        "sysvinit"
-      ])
-    vmTools.debDistros.ubuntu2004x86_64.packages
-    ++ [
-      "systemd"
-      "init-system-helpers"
-      "systemd-sysv"
-      "linux-image-generic"
-      "initramfs-tools"
-      "e2fsprogs"
-      "grub-efi"
-      "apt"
-      "openssh-server"
+  coreutils,
+  tree,
+  bash,
+}: let
+  ubuntuImage = vmTools.makeImageFromDebDist {
+    inherit (vmTools.debDistros.ubuntu2004x86_64) name fullName urlPrefix packagesLists;
+    packages =
+      lib.filter (p:
+        !lib.elem p [
+          "g++"
+          "make"
+          "dpkg-dev"
+          "pkg-config"
+          "sysvinit"
+        ])
+      vmTools.debDistros.ubuntu2004x86_64.packages
+      ++ [
+        "systemd"
+        "init-system-helpers"
+        "systemd-sysv"
+        "linux-image-generic"
+        "initramfs-tools"
+        "e2fsprogs"
+        "grub-efi"
+        "apt"
+        "openssh-server"
+      ];
+    size = 5120; # 5GB in MB
+    createRootFS = ''
+      disk=/dev/vda
+      ${gptfdisk}/bin/sgdisk $disk \
+        -n1:0:+100M -t1:ef00 -c1:esp \
+        -n2:0:0 -t2:8300 -c2:root
+      ${util-linux}/bin/partx -u "$disk"
+      ${dosfstools}/bin/mkfs.vfat -F32 -n ESP "$disk"1
+      part="$disk"2
+      ${e2fsprogs}/bin/mkfs.ext4 "$part" -L root
+      mkdir /mnt
+      ${util-linux}/bin/mount -t ext4 "$part" /mnt
+      mkdir -p /mnt/{proc,dev,sys,boot/efi}
+      ${util-linux}/bin/mount -t vfat "$disk"1 /mnt/boot/efi
+      touch /mnt/.debug
+    '';
+    postInstall = ''
+      ${util-linux}/bin/mount -t proc proc /mnt/proc
+      ${util-linux}/bin/mount -t sysfs sysfs /mnt/sys
+      ${util-linux}/bin/mount -o bind /dev /mnt/dev
+      ${util-linux}/bin/mount -o bind /dev/pts /mnt/dev/pts
+
+      chroot /mnt /bin/bash -exuo pipefail <<CHROOT
+      export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+      echo LABEL=root / ext4 defaults > /etc/fstab
+      update-initramfs -k all -c
+      cat >> /etc/default/grub <<EOF
+      GRUB_TIMEOUT=5
+      GRUB_CMDLINE_LINUX="console=ttyS0"
+      GRUB_CMDLINE_LINUX_DEFAULT=""
+      EOF
+      sed -i '/TIMEOUT_HIDDEN/d' /etc/default/grub
+      update-grub
+      grub-install --target x86_64-efi
+      # Configure networking
+      ln -snf /lib/systemd/resolv.conf /etc/resolv.conf
+      systemctl enable systemd-networkd systemd-resolved
+      cat >/etc/systemd/network/10-eth.network <<NETWORK
+      [Match]
+      Name=en*
+      Name=eth*
+      [Link]
+      RequiredForOnline=true
+      [Network]
+      DHCP=yes
+      NETWORK
+      # Configure SSH
+      rm /etc/ssh/ssh_host_*
+      cat > /etc/systemd/system/generate-host-keys.service <<SERVICE
+      [Install]
+      WantedBy=ssh.service
+      [Unit]
+      Before=ssh.service
+      [Service]
+      ExecStart=dpkg-reconfigure openssh-server
+      SERVICE
+      systemctl enable generate-host-keys
+      # Set root password (you might want to change this)
+      echo root:root | chpasswd
+      # Add your public SSH key here
+      mkdir -p /root/.ssh
+      chmod 0700 /root
+      cat >/root/.ssh/authorized_keys <<KEYS
+      ssh-ed25519 YOUR_PUBLIC_SSH_KEY
+      KEYS
+      CHROOT
+
+      ${util-linux}/bin/umount /mnt/dev/pts
+      ${util-linux}/bin/umount /mnt/dev
+      ${util-linux}/bin/umount /mnt/sys
+      ${util-linux}/bin/umount /mnt/proc
+      ${util-linux}/bin/umount /mnt/boot/efi
+    '';
+  };
+
+  treadmillStore = derivation {
+    name = "treadmill-store";
+    system = builtins.currentSystem;
+    builder = "${bash}/bin/bash";
+    args = [
+      "-c"
+      ''
+        set -euo pipefail
+
+        # Create the base directory structure
+        ${coreutils}/bin/mkdir -p $out/dev-image-store/blobs
+        ${coreutils}/bin/mkdir -p $out/dev-image-store/images
+
+        # Calculate the SHA256 hash of the qcow2 file
+        BLOB_HASH=$(${coreutils}/bin/sha256sum ${ubuntuImage}/disk-image.qcow2 | ${coreutils}/bin/cut -d' ' -f1)
+
+        # Create the blob directory structure and copy the qcow2 file
+        ${coreutils}/bin/mkdir -p $out/dev-image-store/blobs/''${BLOB_HASH:0:2}/''${BLOB_HASH:2:2}/''${BLOB_HASH:4:2}
+        ${coreutils}/bin/cp ${ubuntuImage}/disk-image.qcow2 $out/dev-image-store/blobs/''${BLOB_HASH:0:2}/''${BLOB_HASH:2:2}/''${BLOB_HASH:4:2}/$BLOB_HASH
+
+        # Create the image-specific manifest file
+        ${coreutils}/bin/cat > $out/dev-image-store/image_manifest.toml << EOF
+        manifest_version = "0.0"
+        manifest_extensions = [ "org.tockos.treadmill.manifest-ext.base" ]
+
+        "org.tockos.treadmill.manifest-ext.base.label" = "Ubuntu 20.04 base installation"
+        "org.tockos.treadmill.manifest-ext.base.revision" = 0
+        "org.tockos.treadmill.manifest-ext.base.description" = '''
+        Base Ubuntu 20.04 installation, without any customizations.
+        Minimal packages selected, DHCP network configuration.
+        Credentials: root / root
+        '''
+
+        ["org.tockos.treadmill.manifest-ext.base.attrs"]
+        "org.tockos.treadmill.image.qemu_layered_v0.head" = "layer-0"
+
+        ["org.tockos.treadmill.manifest-ext.base.blobs".layer-0]
+        "org.tockos.treadmill.manifest-ext.base.sha256-digest" = "$BLOB_HASH"
+        "org.tockos.treadmill.manifest-ext.base.size" = $(${coreutils}/bin/stat -c%s ${ubuntuImage}/disk-image.qcow2)
+
+        ["org.tockos.treadmill.manifest-ext.base.blobs".layer-0."org.tockos.treadmill.manifest-ext.base.attrs"]
+        "org.tockos.treadmill.image.qemu_layered_v0.blob-virtual-size" = "5368709120"
+        EOF
+
+        # Calculate the SHA256 hash of the image-specific manifest file
+        IMAGE_HASH=$(${coreutils}/bin/sha256sum $out/dev-image-store/image_manifest.toml | ${coreutils}/bin/cut -d' ' -f1)
+
+        # Create the image-specific directory and move the manifest
+        ${coreutils}/bin/mkdir -p $out/dev-image-store/images/''${IMAGE_HASH:0:2}/''${IMAGE_HASH:2:2}/''${IMAGE_HASH:4:2}
+        ${coreutils}/bin/mv $out/dev-image-store/image_manifest.toml $out/dev-image-store/images/''${IMAGE_HASH:0:2}/''${IMAGE_HASH:2:2}/''${IMAGE_HASH:4:2}/$IMAGE_HASH
+
+        # Create the manifest.toml file in the root of dev-image-store
+        ${coreutils}/bin/cat > $out/dev-image-store/manifest.toml << EOF
+        manifest_version = "0.0"
+        manifest_extensions = [ "org.tockos.treadmill.manifest-ext.base" ]
+
+        "org.tockos.treadmill.manifest-ext.base.label" = "Ubuntu 20.04 base installation"
+        "org.tockos.treadmill.manifest-ext.base.revision" = 0
+        "org.tockos.treadmill.manifest-ext.base.description" = '''
+        Base Ubuntu 20.04 installation, without any customizations.
+        Minimal packages selected, DHCP network configuration.
+        Credentials: root / root
+        '''
+
+        ["org.tockos.treadmill.manifest-ext.base.attrs"]
+        "org.tockos.treadmill.image.qemu_layered_v0.head" = "layer-0"
+
+        ["org.tockos.treadmill.manifest-ext.base.blobs".layer-0]
+        "org.tockos.treadmill.manifest-ext.base.sha256-digest" = "$BLOB_HASH"
+        "org.tockos.treadmill.manifest-ext.base.size" = $(${coreutils}/bin/stat -c%s ${ubuntuImage}/disk-image.qcow2)
+
+        ["org.tockos.treadmill.manifest-ext.base.blobs".layer-0."org.tockos.treadmill.manifest-ext.base.attrs"]
+        "org.tockos.treadmill.image.qemu_layered_v0.blob-virtual-size" = 5368709120
+        EOF
+
+        # Verify the directory structure
+        ${tree}/bin/tree $out/dev-image-store/
+
+        # Output the IMAGE_HASH for future reference
+        ${coreutils}/bin/echo "IMAGE_HASH: $IMAGE_HASH" > $out/image_hash.txt
+      ''
     ];
-  size = 5120; # 5GB in MB
-  createRootFS = ''
-    disk=/dev/vda
-    ${gptfdisk}/bin/sgdisk $disk \
-      -n1:0:+100M -t1:ef00 -c1:esp \
-      -n2:0:0 -t2:8300 -c2:root
-    ${util-linux}/bin/partx -u "$disk"
-    ${dosfstools}/bin/mkfs.vfat -F32 -n ESP "$disk"1
-    part="$disk"2
-    ${e2fsprogs}/bin/mkfs.ext4 "$part" -L root
-    mkdir /mnt
-    ${util-linux}/bin/mount -t ext4 "$part" /mnt
-    mkdir -p /mnt/{proc,dev,sys,boot/efi}
-    ${util-linux}/bin/mount -t vfat "$disk"1 /mnt/boot/efi
-    touch /mnt/.debug
-  '';
-  postInstall = ''
-    ${util-linux}/bin/mount -t proc proc /mnt/proc
-    ${util-linux}/bin/mount -t sysfs sysfs /mnt/sys
-    ${util-linux}/bin/mount -o bind /dev /mnt/dev
-    ${util-linux}/bin/mount -o bind /dev/pts /mnt/dev/pts
-
-    chroot /mnt /bin/bash -exuo pipefail <<CHROOT
-    export PATH=/usr/sbin:/usr/bin:/sbin:/bin
-    echo LABEL=root / ext4 defaults > /etc/fstab
-    update-initramfs -k all -c
-    cat >> /etc/default/grub <<EOF
-    GRUB_TIMEOUT=5
-    GRUB_CMDLINE_LINUX="console=ttyS0"
-    GRUB_CMDLINE_LINUX_DEFAULT=""
-    EOF
-    sed -i '/TIMEOUT_HIDDEN/d' /etc/default/grub
-    update-grub
-    grub-install --target x86_64-efi
-    # Configure networking
-    ln -snf /lib/systemd/resolv.conf /etc/resolv.conf
-    systemctl enable systemd-networkd systemd-resolved
-    cat >/etc/systemd/network/10-eth.network <<NETWORK
-    [Match]
-    Name=en*
-    Name=eth*
-    [Link]
-    RequiredForOnline=true
-    [Network]
-    DHCP=yes
-    NETWORK
-    # Configure SSH
-    rm /etc/ssh/ssh_host_*
-    cat > /etc/systemd/system/generate-host-keys.service <<SERVICE
-    [Install]
-    WantedBy=ssh.service
-    [Unit]
-    Before=ssh.service
-    [Service]
-    ExecStart=dpkg-reconfigure openssh-server
-    SERVICE
-    systemctl enable generate-host-keys
-    # Set root password (you might want to change this)
-    echo root:root | chpasswd
-    # Add your public SSH key here
-    mkdir -p /root/.ssh
-    chmod 0700 /root
-    cat >/root/.ssh/authorized_keys <<KEYS
-    ssh-ed25519 YOUR_PUBLIC_SSH_KEY
-    KEYS
-    # Place your config files here
-    # For example:
-    # cat > /etc/myconfig.conf <<CONFIG
-    # your_config_content_here
-    # CONFIG
-    # Place your public binary here
-    # For example:
-    # cp /path/to/custom_binary /usr/local/bin/
-    # chmod +x /usr/local/bin/custom_binary
-    CHROOT
-
-    ${util-linux}/bin/umount /mnt/dev/pts
-    ${util-linux}/bin/umount /mnt/dev
-    ${util-linux}/bin/umount /mnt/sys
-    ${util-linux}/bin/umount /mnt/proc
-    ${util-linux}/bin/umount /mnt/boot/efi
-  '';
+    buildInputs = [coreutils tree];
+  };
+in {
+  inherit ubuntuImage treadmillStore;
 }

--- a/treadmill-rs/src/image/image_generator/ubuntu-image.nix
+++ b/treadmill-rs/src/image/image_generator/ubuntu-image.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  vmTools,
+  udev,
+  gptfdisk,
+  util-linux,
+  dosfstools,
+  e2fsprogs,
+  systemd,
+}:
+vmTools.makeImageFromDebDist {
+  inherit (vmTools.debDistros.ubuntu2004x86_64) name fullName urlPrefix packagesLists;
+  packages =
+    lib.filter (p:
+      !lib.elem p [
+        "g++"
+        "make"
+        "dpkg-dev"
+        "pkg-config"
+        "sysvinit"
+      ])
+    vmTools.debDistros.ubuntu2004x86_64.packages
+    ++ [
+      "systemd"
+      "init-system-helpers"
+      "systemd-sysv"
+      "linux-image-generic"
+      "initramfs-tools"
+      "e2fsprogs"
+      "grub-efi"
+      "apt"
+      "openssh-server"
+    ];
+  size = 5120; # 5GB in MB
+  createRootFS = ''
+    disk=/dev/vda
+    ${gptfdisk}/bin/sgdisk $disk \
+      -n1:0:+100M -t1:ef00 -c1:esp \
+      -n2:0:0 -t2:8300 -c2:root
+    ${util-linux}/bin/partx -u "$disk"
+    ${dosfstools}/bin/mkfs.vfat -F32 -n ESP "$disk"1
+    part="$disk"2
+    ${e2fsprogs}/bin/mkfs.ext4 "$part" -L root
+    mkdir /mnt
+    ${util-linux}/bin/mount -t ext4 "$part" /mnt
+    mkdir -p /mnt/{proc,dev,sys,boot/efi}
+    ${util-linux}/bin/mount -t vfat "$disk"1 /mnt/boot/efi
+    touch /mnt/.debug
+  '';
+  postInstall = ''
+    ${util-linux}/bin/mount -t proc proc /mnt/proc
+    ${util-linux}/bin/mount -t sysfs sysfs /mnt/sys
+    ${util-linux}/bin/mount -o bind /dev /mnt/dev
+    ${util-linux}/bin/mount -o bind /dev/pts /mnt/dev/pts
+
+    chroot /mnt /bin/bash -exuo pipefail <<CHROOT
+    export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+    echo LABEL=root / ext4 defaults > /etc/fstab
+    update-initramfs -k all -c
+    cat >> /etc/default/grub <<EOF
+    GRUB_TIMEOUT=5
+    GRUB_CMDLINE_LINUX="console=ttyS0"
+    GRUB_CMDLINE_LINUX_DEFAULT=""
+    EOF
+    sed -i '/TIMEOUT_HIDDEN/d' /etc/default/grub
+    update-grub
+    grub-install --target x86_64-efi
+    # Configure networking
+    ln -snf /lib/systemd/resolv.conf /etc/resolv.conf
+    systemctl enable systemd-networkd systemd-resolved
+    cat >/etc/systemd/network/10-eth.network <<NETWORK
+    [Match]
+    Name=en*
+    Name=eth*
+    [Link]
+    RequiredForOnline=true
+    [Network]
+    DHCP=yes
+    NETWORK
+    # Configure SSH
+    rm /etc/ssh/ssh_host_*
+    cat > /etc/systemd/system/generate-host-keys.service <<SERVICE
+    [Install]
+    WantedBy=ssh.service
+    [Unit]
+    Before=ssh.service
+    [Service]
+    ExecStart=dpkg-reconfigure openssh-server
+    SERVICE
+    systemctl enable generate-host-keys
+    # Set root password (you might want to change this)
+    echo root:root | chpasswd
+    # Add your public SSH key here
+    mkdir -p /root/.ssh
+    chmod 0700 /root
+    cat >/root/.ssh/authorized_keys <<KEYS
+    ssh-ed25519 YOUR_PUBLIC_SSH_KEY
+    KEYS
+    # Place your config files here
+    # For example:
+    # cat > /etc/myconfig.conf <<CONFIG
+    # your_config_content_here
+    # CONFIG
+    # Place your public binary here
+    # For example:
+    # cp ./custom_binary /usr/local/bin/
+    # chmod +x /usr/local/bin/custom_binary
+    CHROOT
+
+    ${util-linux}/bin/umount /mnt/dev/pts
+    ${util-linux}/bin/umount /mnt/dev
+    ${util-linux}/bin/umount /mnt/sys
+    ${util-linux}/bin/umount /mnt/proc
+    ${util-linux}/bin/umount /mnt/boot/efi
+  '';
+}


### PR DESCRIPTION
This PR adds a custom Ubuntu image generator below are instructions for how to use it, I tested it and am able to create an arbitrary image, and then ssh into it after running it with QEMU with no extra setup required

# Building and Running a Custom Ubuntu QEMU (.qcow2) VM Image with Nix

## Prerequisites

Ensure you have the following files in your working directory:

- `ubuntu-image.nix`
- `default.nix`
- `run-ubuntu-vm.nix`

Please make sure to replace `YOUR_PUBLIC_SSH_KEY` with your public ssh key

## Steps

1. Build the Ubuntu image:

   ```bash
   nix-build
   ```

2. Copy the image out of the Nix store:

   ```bash
   cp result/disk-image.qcow2 ~/ubuntu-image.qcow2
   ```

3. Set appropriate permissions on the image file:

   ```bash
   chmod 644 ~/ubuntu-image.qcow2
   ```

4. Build the VM runner script:

   ```bash
   nix-build run-ubuntu-vm.nix
   ```

5. Run the VM:

   ```bash
   ./result/bin/run-ubuntu-vm ~/ubuntu-image.qcow2
   ```

6. Once the VM boots, you'll see a login prompt. Log in as root with the password "root".

7. To SSH into the VM from another terminal window:
   ```bash
   ssh -p 2222 root@localhost
   ```
   Use the password "root" when prompted.

## Additional Notes

- To modify the image, edit `ubuntu-image.nix` and repeat steps 1-3.
- To change VM runtime parameters, edit `run-ubuntu-vm.nix` and repeat steps 4-5.
- Remember to copy the image out of the Nix store and reset permissions after each rebuild.
- For security, change the root password after first login.
- Update or remove the SSH key in `ubuntu-image.nix` before sharing the image.