### PR TITLE
ci-build: check that lockfile is current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,5 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build all crates
         run: |
-          cargo build
+          # Pass --locked to ensure that the lockfile in the repository stays current
+          cargo build --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,17 +133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,12 +2740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strfmt"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8348af2d9fc3258c8733b8d9d8db2e56f54b2363a4b5b81585c7875ed65e65"
-
-[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,29 +2975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tml-qemu-supervisor"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-recursion",
- "async-trait",
- "clap",
- "log",
- "serde",
- "serde_json",
- "simplelog",
- "strfmt",
- "tempfile",
- "tml-cli-connector",
- "tml-tcp-control-socket-server",
- "tml-ws-connector",
- "tokio",
- "toml",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
 name = "tml-switchboard"
 version = "0.1.0"
 dependencies = [
@@ -3035,7 +2995,6 @@ dependencies = [
  "parking_lot",
  "rand 0.9.0-alpha.2",
  "rand_chacha 0.9.0-alpha.2",
- "rand_core 0.9.0-alpha.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -3213,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a44eede9b727419af8095cb2d72fab15487a541f54647ad4414b34096ee4631"
+checksum = "73b98404c41291d0a0fba7148837d26858b42e57f7abe5a4865ff39dc35d1d8c"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3234,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.18"
+version = "0.22.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1490595c74d930da779e944f5ba2ecdf538af67df1a9848cbd156af43c1b7cf0"
+checksum = "4866f4796a39e03923b14f9a42e88f223e2e685ee1851041e510c0134850c27f"
 dependencies = [
  "indexmap 2.2.6",
  "serde",


### PR DESCRIPTION
This adds `--locked` to `cargo build` in our CI workflow, which in turn ensures that the checked in `Cargo.lock` stays current.

The first commit does not update `Cargo.lock`, and as such fails CI:

```
  # Pass --locked to ensure that the lockfile in the repository stays current
  cargo build --locked
  shell: /usr/bin/bash -e {0}
  env:
    TERM: xterm
    CARGO_INCREMENTAL: 0
    CARGO_PROFILE_DEV_DEBUG: 0
    CARGO_TERM_COLOR: always
    RUST_BACKTRACE: short
    RUSTFLAGS: -D warnings
    CARGO_UNSTABLE_SPARSE_REGISTRY: true
    CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
    CACHE_ON_FAILURE: true
error: the lock file /home/runner/work/treadmill/treadmill/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
Error: Process completed with exit code 101.
```

With the second commit, updating `Cargo.lock`, CI passes again.