### PR TITLE
Add QEMU Supervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,6 +2751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strfmt"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8348af2d9fc3258c8733b8d9d8db2e56f54b2363a4b5b81585c7875ed65e65"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,6 +2989,29 @@ dependencies = [
  "tml-tcp-control-socket-client",
  "tokio",
  "treadmill-rs",
+]
+
+[[package]]
+name = "tml-qemu-supervisor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-recursion",
+ "async-trait",
+ "clap",
+ "log",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "strfmt",
+ "tempfile",
+ "tml-cli-connector",
+ "tml-tcp-control-socket-server",
+ "tml-ws-connector",
+ "tokio",
+ "toml",
+ "treadmill-rs",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [workspace]
 resolver = "2"
 members = [
-    "treadmill-rs",
-    "puppet",
-    "control-socket/tcp/client",
-    "control-socket/tcp/server",
-    "supervisor/mock",
     "connector/cli",
     "connector/ws",
+    "control-socket/tcp/client",
+    "control-socket/tcp/server",
+    "puppet",
+    "supervisor/mock",
+    "supervisor/qemu",
     "switchboard/switchboard",
+    "treadmill-rs",
 ]
 
 [workspace.package]

--- a/control-socket/tcp/server/src/lib.rs
+++ b/control-socket/tcp/server/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -16,10 +17,18 @@ enum ControlSocketTaskCommand {
 }
 
 pub struct TcpControlSocket<S: Supervisor> {
-    _job_id: Uuid,
+    job_id: Uuid,
     task_handle: JoinHandle<Result<()>>,
     task_cmd_chan: tokio::sync::mpsc::Sender<ControlSocketTaskCommand>,
     _supervisor: Arc<S>,
+}
+
+impl<S: Supervisor> fmt::Debug for TcpControlSocket<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("TcpControlSocket")
+            .field("job_id", &self.job_id)
+            .finish()
+    }
 }
 
 impl<S: Supervisor> TcpControlSocket<S> {
@@ -172,7 +181,7 @@ impl<S: Supervisor> TcpControlSocket<S> {
         });
 
         Ok(TcpControlSocket {
-            _job_id: job_id,
+            job_id,
             task_handle,
             task_cmd_chan: task_cmd_chan_tx,
             _supervisor: supervisor,

--- a/supervisor/qemu/.gitignore
+++ b/supervisor/qemu/.gitignore
@@ -1,0 +1,5 @@
+# State directory, for development with default config
+/state
+
+# Image store, for development with default config
+/image-store

--- a/supervisor/qemu/Cargo.toml
+++ b/supervisor/qemu/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tml-qemu-supervisor"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+treadmill-rs = { path = "../../treadmill-rs" }
+tml-tcp-control-socket-server = { path = "../../control-socket/tcp/server" }
+tml-cli-connector = { path = "../../connector/cli" }
+tml-ws-connector = { path = "../../connector/ws" }
+
+tokio = { version = "1.35.1", default-features = false, features = ["rt-multi-thread", "process", "fs"] }
+toml = "0.8.8"
+uuid = "1.6.1"
+serde = { version = "1.0.193", features = ["derive"] }
+clap = { version = "4.4.11", features = ["derive"] }
+simplelog = "0.12.1"
+log = "0.4.20"
+async-trait = "0.1.75"
+anyhow = "1.0.76"
+tempfile = "3.10.1"
+strfmt = "0.2.4"
+async-recursion = "1.1.1"
+serde_json = "1.0.117"

--- a/supervisor/qemu/config.example.toml
+++ b/supervisor/qemu/config.example.toml
@@ -1,0 +1,47 @@
+[base]
+supervisor_id = "7d55ec6d-15e7-4b84-8c04-7c085fe60df4"
+coord_connector = "cli_connector"
+
+[cli_connector]
+# Doesn't do anything yet, but we require the images key to be present
+images = { }
+
+[image_store]
+# Doesn't do anything yet. This endpoint will be used to request
+# images to be downloaded etc. later on:
+http_endpoint = "https://localhost:8080"
+
+# Local mountpoint of the read-only image store:
+fs_endpoint = "./image-store"
+
+[qemu]
+qemu_binary = "qemu-kvm"
+qemu_img_binary = "qemu-img"
+
+state_dir = "./state"
+
+qemu_args = [
+    # Misc:
+    "-name", "tml-{job_id}",
+    "-nographic",
+    # Base machine configuration:
+    "-machine", "q35",
+    "-m", "4G",
+    # Storage:
+    "-device", "virtio-scsi-pci,id=scsi0",
+    "-drive", "file={main_disk_image},id=drive0,format=qcow2,if=none",
+    "-device", "scsi-hd,drive=drive0,bus=scsi0.0",
+    # Network:
+    "-netdev", "user,id=net0",
+    "-device", "virtio-net-pci,id=nic0,netdev=net0",
+    # Treamill-specific attributes:
+    # (10.0.2.2 is the host address in QEMU SLIRP networking)
+    "-fw_cfg", "name=opt/org.tockos.treadmill.tcp-ctrl-socket,string=10.0.2.2:3859",
+]
+
+tcp_control_socket_listen_addr = "0.0.0.0:3859"
+
+# Each VM will have at most 32GB to work with. This should be
+# sufficient to support most images, even heavy-weight toolchains
+# (such as OpenTitan with Bazel and Vivado Lab tools)
+working_disk_max_bytes = 34359738368

--- a/supervisor/qemu/src/image_store_client.rs
+++ b/supervisor/qemu/src/image_store_client.rs
@@ -1,0 +1,163 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use log::warn;
+use serde::Deserialize;
+
+use treadmill_rs::image::manifest::{ImageId, ImageManifest};
+
+const DIGEST_BYTES_NEST_LEVEL: usize = 3;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LocalImageStoreConfig {
+    pub fs_endpoint: PathBuf,
+    pub http_endpoint: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FetchImageStatus {
+    /// The image is currently being fetched. An image store may provide an
+    /// optional message indicating the status of this operation.
+    InProgress(Option<String>),
+    /// The image has been fetched successfully, or is already present at this
+    /// image store. It is available for use via the other API endpoints.
+    Present,
+}
+
+#[derive(Debug)]
+pub struct ImageStoreClient {
+    _http_endpoint: String,
+}
+
+pub fn digest_tree_path<P: AsRef<Path>>(base: P, digest: &[u8], nest_level: usize) -> PathBuf {
+    let mut current_path: PathBuf = base.as_ref().into();
+
+    // Digest path nested into a `nest_level` deep subdirectory
+    // hiearchy built from its first bytes.
+    for (_level, byte) in (0..nest_level).zip(digest.iter()) {
+        current_path =
+            current_path.join(treadmill_rs::util::hex_slice::HexSlice(&[*byte]).to_string());
+    }
+
+    // Finally, add the full digest:
+    current_path.join(treadmill_rs::util::hex_slice::HexSlice(digest).to_string())
+}
+
+impl ImageStoreClient {
+    pub async fn new(http_endpoint: String) -> Result<Self> {
+        Ok(ImageStoreClient {
+            _http_endpoint: http_endpoint,
+        })
+    }
+
+    pub async fn into_local<I: Into<PathBuf>>(
+        self,
+        fs_endpoint: I,
+    ) -> Result<LocalImageStoreClient, (anyhow::Error, Self)> {
+        LocalImageStoreClient::new(self, fs_endpoint).await
+    }
+
+    // TODO: authentication?
+    pub async fn fetch_image(
+        &self,
+        _remote_store_endpoints: Vec<String>,
+        _image_id: ImageId,
+    ) -> Result<FetchImageStatus> {
+        warn!(
+            "Image store client was instructed to fetch an image, which is \
+	     currently unimplemented. Returning an unconditional \
+	     FetchImageStatus::Present."
+        );
+
+        Ok(FetchImageStatus::Present)
+    }
+
+    pub async fn image_manifest(&self, _image_id: ImageId) -> Result<ImageManifest> {
+        bail!("Fetching image manifests via HTTP is not implement.")
+    }
+}
+
+#[derive(Debug)]
+pub struct LocalImageStoreClient {
+    image_store_client: ImageStoreClient,
+    fs_endpoint: PathBuf,
+}
+
+impl LocalImageStoreClient {
+    pub async fn new<I: Into<PathBuf>>(
+        image_store_client: ImageStoreClient,
+        fs_endpoint: I,
+    ) -> Result<Self, (anyhow::Error, ImageStoreClient)> {
+        Ok(LocalImageStoreClient {
+            image_store_client,
+            fs_endpoint: fs_endpoint.into(),
+        })
+    }
+
+    pub fn into_inner(self) -> ImageStoreClient {
+        self.image_store_client
+    }
+
+    pub fn inner(&self) -> &ImageStoreClient {
+        &self.image_store_client
+    }
+
+    pub fn inner_mut(&mut self) -> &mut ImageStoreClient {
+        &mut self.image_store_client
+    }
+
+    pub async fn blob_path(&self, blob_sha256_digest: &[u8; 32]) -> PathBuf {
+        digest_tree_path(
+            self.fs_endpoint.join("blobs"),
+            blob_sha256_digest,
+            DIGEST_BYTES_NEST_LEVEL,
+        )
+    }
+
+    pub async fn image_path(&self, image_id: ImageId) -> PathBuf {
+        digest_tree_path(
+            self.fs_endpoint.join("images"),
+            &image_id.0,
+            DIGEST_BYTES_NEST_LEVEL,
+        )
+    }
+
+    pub async fn fetch_image(
+        &self,
+        remote_store_endpoints: Vec<String>,
+        image_id: ImageId,
+    ) -> Result<FetchImageStatus> {
+        self.image_store_client
+            .fetch_image(remote_store_endpoints, image_id)
+            .await
+    }
+
+    pub async fn image_manifest(&self, image_id: ImageId) -> Result<ImageManifest> {
+        // Only do a local lookup here. If the image store holds the image and
+        // has a filesystem endpoint, it should also expose it there.
+        let manifest_path = self.image_path(image_id).await;
+
+        let manifest_bytes = tokio::fs::read(&manifest_path).await.with_context(|| {
+            format!(
+                "Reading manifest of image {:?} at {:?}",
+                image_id, manifest_path
+            )
+        })?;
+
+        std::str::from_utf8(&manifest_bytes)
+            .with_context(|| {
+                format!(
+                    "Interpreting manifest of image {:?} as UTF-8 string",
+                    image_id
+                )
+            })
+            .and_then(|manifest_str| -> Result<ImageManifest> {
+                toml::from_str(manifest_str).with_context(|| {
+                    format!(
+                        "Parsing manifest of image {:?} as TOML-encoded ImageManifest object",
+                        image_id
+                    )
+                })
+            })
+    }
+}

--- a/supervisor/qemu/src/main.rs
+++ b/supervisor/qemu/src/main.rs
@@ -1,0 +1,1462 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use async_recursion::async_recursion;
+use async_trait::async_trait;
+use clap::Parser;
+use log::{debug, info, warn};
+use serde::Deserialize;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use treadmill_rs::api::switchboard_supervisor::JobInitSpec;
+use treadmill_rs::connector;
+use treadmill_rs::control_socket;
+use treadmill_rs::image;
+use treadmill_rs::supervisor::{SupervisorBaseConfig, SupervisorCoordConnector};
+
+use tml_tcp_control_socket_server::TcpControlSocket;
+
+mod image_store_client;
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+struct QemuImgChildMetadataInfo {
+    // We're only interested in the filename here, to make sure that the
+    // image has only one child node, and that node coincides with the
+    // file that we're operating on.
+    filename: PathBuf,
+
+    // Include this field just to make sure that we don't have
+    // any recursive children:
+    children: Vec<QemuImgChildMetadata>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+struct QemuImgChildMetadata {
+    info: QemuImgChildMetadataInfo,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+struct QemuImgMetadata {
+    filename: PathBuf,
+    virtual_size: u64,
+    children: Vec<QemuImgChildMetadata>,
+    encrypted: Option<bool>,
+    backing_filename_format: Option<String>,
+    // According to [1], these attributes are described as
+    // - backing-filename: name of the backing file
+    // - full-backing-filename: full path of the backing file
+    //
+    // In practice it seems that `full-backing-filename` points to the
+    // resolved path of the backing file (relative to the current
+    // working directory), whereas `backing-filename` is just the raw
+    // attribute stored in the image.
+    //
+    // [1]: https://www.qemu.org/docs/master/interop/qemu-storage-daemon-qmp-ref.html
+    backing_filename: Option<PathBuf>,
+    full_backing_filename: Option<PathBuf>,
+}
+
+async fn fuse<R>(duration: std::time::Duration, fire: impl std::future::Future<Output = R>) -> R {
+    // Cancellable await:
+    tokio::time::sleep(duration).await;
+
+    // Boom:
+    fire.await
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct QemuSupervisorArgs {
+    /// Path to the TOML configuration file
+    #[arg(short, long)]
+    config_file: PathBuf,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum SSHPreferredIPVersion {
+    Unspecified,
+    V4,
+    V6,
+}
+
+impl Default for SSHPreferredIPVersion {
+    fn default() -> Self {
+        SSHPreferredIPVersion::Unspecified
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct QemuConfig {
+    /// Main QEMU binary to execute for a job.
+    qemu_binary: PathBuf,
+
+    /// `qemu-img` binary, to work with qcow2 files.
+    qemu_img_binary: PathBuf,
+
+    /// Directory to keep state:
+    state_dir: PathBuf,
+
+    /// List of arguments to pass to the QEMU binary.
+    ///
+    /// These arguments support template strings using the
+    /// [`strfmt`](https://docs.rs/strfmt/latest/strfmt/) crate.q
+    ///
+    /// The available template strings are:
+    ///
+    /// - `job_id`: UUID as a hyphenated string
+    ///
+    /// - `qcow2_disk`: main `qcow2` disk, which may be an overlay. In the case
+    ///   that it is an overlay, it is set up such that all other layers can be
+    ///   correctly resolved (relative to the current working directory)
+    ///
+    /// - `tcp_control_socket_listen_addr: full socket address, with IPv6
+    ///   address properly enclosed in square brackets, e.g., `[::1]:8080`
+    qemu_args: Vec<String>,
+
+    /// Maximum "working" disk image to be allocated for a job, in bytes.
+    ///
+    /// These are thinly provisioned qcow2 CoW files, and so don't necessarily
+    /// take up this much space. However, all images will be extended to this
+    /// size, and the virtual machine can then resize its internal partitions
+    /// accordingly.
+    ///
+    /// The runner will be unable to execute any images that have a disk image
+    /// with a size larger than this limit (even though the sparse qcow2 file
+    /// may be smaller), as otherwise the image exposed to the VM may cut off a
+    /// part of the image at the end.
+    working_disk_max_bytes: u64,
+
+    tcp_control_socket_listen_addr: std::net::SocketAddr,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct QemuSupervisorConfig {
+    /// Base configuration, identical across all supervisors:
+    base: SupervisorBaseConfig,
+
+    /// Configurations for individual connector implementations. All are
+    /// optional, and not all of them have to be supported:
+    cli_connector: Option<tml_cli_connector::CliConnectorConfig>,
+
+    ws_connector: Option<tml_ws_connector::WsConnectorConfig>,
+
+    image_store: image_store_client::LocalImageStoreConfig,
+
+    qemu: QemuConfig,
+}
+
+#[derive(Debug)]
+pub struct QemuSupervisorFetchingImageState {
+    start_job_req: connector::StartJobMessage,
+    image_id: image::manifest::ImageId,
+    poll_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[derive(Debug)]
+pub struct QemuSupervisorImageFetchedState {
+    start_job_req: connector::StartJobMessage,
+    image_id: image::manifest::ImageId,
+    manifest: image::manifest::ImageManifest,
+}
+
+#[derive(Debug)]
+pub struct QemuSupervisorJobRunningState {
+    start_job_req: connector::StartJobMessage,
+
+    /// The qemu process handle:
+    qemu_proc: tokio::process::Child,
+
+    /// Control socket handle:
+    control_socket: TcpControlSocket<QemuSupervisor>,
+    // /// Set of rendezvous proxy connections:
+    // ssh_rendezvous_proxies: Vec<rendezvous_proxy::RendezvousProxy>,
+}
+
+#[derive(Debug)]
+pub enum QemuSupervisorJobState {
+    /// State to indicate that the job is starting.
+    ///
+    /// We use this to reserve a spot in the [`QemuSupervisor`]'s `jobs` map,
+    /// such that we can release the global HashMap lock afterwards.
+    Starting,
+
+    /// State to indicate that we're currently waiting on the image to
+    /// be fetched. This state polls the image store with a fixed
+    /// interval.
+    FetchingImage(QemuSupervisorFetchingImageState),
+
+    /// The job's image has been fully fetched, and we're alloating resources
+    /// and starting it. It's not fully up and running yet.
+    ImageFetched(QemuSupervisorImageFetchedState),
+
+    /// State to indicate that the job is running.
+    Running(QemuSupervisorJobRunningState),
+
+    /// State to indicate that the job is currently shutting down.
+    ///
+    /// While the job is in this state, no job with the same ID must be started
+    /// / resumed. We might still be cleaning up resources associated with this
+    /// job.
+    Stopping,
+}
+
+impl QemuSupervisorJobState {
+    fn state_name(&self) -> &'static str {
+        match self {
+            QemuSupervisorJobState::Starting => "Starting",
+            QemuSupervisorJobState::FetchingImage(_) => "FetchingImage",
+            QemuSupervisorJobState::ImageFetched(_) => "ImageFetched",
+            QemuSupervisorJobState::Running(_) => "Running",
+            QemuSupervisorJobState::Stopping => "Stopping",
+        }
+    }
+}
+
+pub struct QemuSupervisor {
+    /// Connector to the central coordinator. All communication is mediated
+    /// through this connector.
+    connector: Arc<dyn connector::SupervisorConnector>,
+
+    /// Image store client, connected to the local image cache. We expect to be
+    /// provided an image store client with a filesystem endpoint, from which we
+    /// can directly reference (immutable) qcow2 images.
+    image_store_client: image_store_client::LocalImageStoreClient,
+
+    /// We support running multiple jobs on one supervisor (in particular when
+    /// not sharing hardware resources), so use a map of `Arc`s behind a mutex
+    /// to avoid locking the map across long-running calls.
+    jobs: Mutex<HashMap<Uuid, Arc<Mutex<QemuSupervisorJobState>>>>,
+
+    _args: QemuSupervisorArgs,
+    config: QemuSupervisorConfig,
+}
+
+impl QemuSupervisor {
+    pub fn new(
+        connector: Arc<dyn connector::SupervisorConnector>,
+        image_store_client: image_store_client::LocalImageStoreClient,
+        args: QemuSupervisorArgs,
+        config: QemuSupervisorConfig,
+    ) -> Self {
+        QemuSupervisor {
+            connector,
+            image_store_client,
+            jobs: Mutex::new(HashMap::new()),
+            _args: args,
+            config,
+        }
+    }
+
+    async fn remove_job(&self, job_id: Uuid) -> Option<Arc<Mutex<QemuSupervisorJobState>>> {
+        self.jobs.lock().await.remove(&job_id)
+    }
+
+    #[async_recursion]
+    async fn fetch_image(this: &Arc<Self>, job_id: Uuid) {
+        // This function can either be called directly from `start_job`, or by
+        // polling on the image fetch operation.
+        //
+        // It may be possible that we cancel the poll task, but race with it
+        // already scheduling another invocation of this `fetch_image` function.
+        // However, in this case, we'll also have transitioned the job into the
+        // `ImageFetched` state. Thus, if the job is in any state other than
+        // `FetchingImage`, we just exit without doing anything:
+        let job_opt = {
+            // Do not hold onto the global job's lock:
+            this.jobs.lock().await.get(&job_id).cloned()
+        };
+
+        // If the job is no longer alive, return:
+        let job = match job_opt {
+            Some(job) => job,
+            None => {
+                // This case should be pretty rare but does not indicate a bug
+                // per se, so let's issue a debug message just in case:
+                debug!(
+                    "Job {:?} vanished across invocations of `fetch_image`",
+                    job_id
+                );
+                return;
+            }
+        };
+
+        // Acquire a lock on the job:
+        let mut job_lg = job.lock().await;
+
+        // We swap in a state of `Starting` temporarily to please the Rust
+        // borrow checker. Before we leave this function, we must replace this
+        // state again!
+        //
+        // If the job is in any state other than `FetchingImage`, swap back and
+        // return immediately:
+        let fetching_image_state =
+            match std::mem::replace(&mut *job_lg, QemuSupervisorJobState::Starting) {
+                QemuSupervisorJobState::FetchingImage(state) => state,
+                prev_state => {
+                    // Swap the old state back:
+                    *job_lg = prev_state;
+
+                    // Same as above, let's issue a debug message:
+                    debug!(
+                        "Job {:?} changed state across invocations of \
+			 `fetch_image`: {:?}",
+                        job_id, job,
+                    );
+
+                    return;
+                }
+            };
+
+        // Check whether the image store already holds this image. If it does,
+        // we can pass the manifest to the `start_job_cont` function. Otherwise,
+        // (continue) polling:
+        match this
+            .image_store_client
+            .fetch_image(
+                // TODO: pass remote store endpoints:
+                vec![],
+                fetching_image_state.image_id,
+            )
+            .await
+        {
+            Ok(image_store_client::FetchImageStatus::Present) => {
+                // Image is fetched, retrieve its manifest and pass it onto
+                // `start_job_cont`. Retrieving the manifest should not fail.
+                //
+                // Don't need to post a status update to the coordinator
+                // here. If we didn't need to fetch an image, this will simply
+                // skip reporting the `FetchingImage` starting stage, and if we
+                // do need to fetch one this will be reported below.
+                //
+                // The transition to `start_job_cont` will then report a
+                // subsequent status, such as `Allocating`.
+
+                let manifest = match this
+                    .image_store_client
+                    .image_manifest(fetching_image_state.image_id)
+                    .await
+                {
+                    Ok(manifest) => manifest,
+                    Err(manifest_err) => {
+                        // We could not retrieve the manifest, despite the image
+                        // being present. Don't attempt to recover from this
+                        // error and mark the job as failed:
+                        this.connector
+                            .report_job_error(
+                                fetching_image_state.start_job_req.job_id,
+                                connector::JobError {
+                                    error_kind: connector::JobErrorKind::InternalError,
+                                    description: format!(
+                                        "Cannot retrieve image manifest of {:?}: {:?}",
+                                        fetching_image_state.image_id, manifest_err,
+                                    ),
+                                },
+                            )
+                            .await;
+
+                        // No resources have been allocated (yet), so simply
+                        // remove the job and set its state to `Stopping`, in
+                        // case anyone else has a reference to it still.
+                        //
+                        // Safe to call, we don't hold a lock on `this.jobs`:
+                        this.remove_job(job_id).await;
+
+                        // Prevent other tasks from further advancing this job's state:
+                        *job_lg = QemuSupervisorJobState::Stopping;
+
+                        return;
+                    }
+                };
+
+                // Place the job in the `ImageFetched` state and continue
+                // starting it. This prevents any other poll task firing this
+                // function from calling `start_job_cont` twice:
+                *job_lg = QemuSupervisorJobState::ImageFetched(QemuSupervisorImageFetchedState {
+                    start_job_req: fetching_image_state.start_job_req,
+                    image_id: fetching_image_state.image_id,
+                    manifest,
+                });
+
+                // Release the lock before continuing to start, otherwise this
+                // will deadlock:
+                std::mem::drop(job_lg);
+                Self::start_job_cont(this, job_id).await
+            }
+
+            Ok(image_store_client::FetchImageStatus::InProgress(msg)) => {
+                // We still need to wait a bit until the image is available.
+                // Poll again in 15 sec, and post this status to the
+                // coordinator.
+
+                // Start a new task that will run this function in 15 sec. We'll
+                // want to cancel it when we perform any state transition
+                // outside of this function:
+                let poll_task_this_weak = Arc::downgrade(this);
+                let poll_task =
+                    tokio::task::spawn(fuse(std::time::Duration::from_secs(15), async move {
+                        if let Some(poll_task_this) = poll_task_this_weak.upgrade() {
+                            Self::fetch_image(&poll_task_this, job_id).await
+                        }
+                    }));
+
+                this.connector
+                    .update_job_state(
+                        fetching_image_state.start_job_req.job_id,
+                        connector::JobState::Starting {
+                            stage: connector::JobStartingStage::FetchingImage,
+                            status_message: msg,
+                        },
+                    )
+                    .await;
+
+                // Put the job into the `FetchingImage` state:
+                *job_lg = QemuSupervisorJobState::FetchingImage(QemuSupervisorFetchingImageState {
+                    poll_task: Some(poll_task),
+                    ..fetching_image_state
+                });
+            }
+
+            Err(e) => {
+                // We could not fetch the image, report an error:
+                this.connector
+                    .report_job_error(
+                        fetching_image_state.start_job_req.job_id,
+                        connector::JobError {
+                            error_kind: connector::JobErrorKind::InternalError,
+                            description: format!(
+                                "Failed to fetch image {:?}: {:?}",
+                                fetching_image_state.image_id, e
+                            ),
+                        },
+                    )
+                    .await;
+
+                // No resources have been allocated (yet), so simply remove the
+                // job and set its state to `Stopping`, in case anyone else has
+                // a reference to it still.
+                //
+                // Safe to call, we don't hold a lock on `this.jobs`:
+                this.remove_job(job_id).await;
+
+                // Prevent other tasks from further advancing this job's state:
+                *job_lg = QemuSupervisorJobState::Stopping;
+            }
+        }
+    }
+
+    async fn start_job_parse_manifest_check_images(
+        &self,
+        manifest: &image::manifest::ImageManifest,
+    ) -> Result<(PathBuf, QemuImgMetadata)> {
+        // Retrieve the "top-most" layer in the image manifest, from which we'll
+        // create our "working" disk image overlay:
+        let top_layer_label = manifest
+            .attrs
+            .get("org.tockos.treadmill.image.qemu_layered_v0.head")
+            .ok_or(anyhow!("Image does not have a head layer defined"))?;
+
+        // Now step through each image layer, making sure that it exists and (if
+        // it has a predecessor defined) it points to that predecessor. We don't
+        // want images to be able to reference arbitrary paths in our filesystem
+        // as underlying layers.
+        //
+        // We use qemu-img to retrieve the (partial) metadata of an image.
+
+        // Now, for every image in the chain, parse the metadata and make sure
+        // that the image file:
+        //
+        // - Exists,
+        // - Matches its specification in the manifest, and
+        // - Only references its defined predecessor.
+        let mut top_image = None;
+        let mut current_image = top_layer_label;
+        loop {
+            // Acquire the manifest metadata for this image blob:
+            let blob_spec = manifest
+                .blobs
+                .get(current_image)
+                .ok_or_else(|| anyhow!("Image missing blob {}", current_image))?;
+
+            // Try to read image attributes with `qemu-img`:
+            let image_path = self
+                .image_store_client
+                .blob_path(&blob_spec.sha256_digest)
+                .await;
+
+            let image_path_canon =
+                tokio::fs::canonicalize(&image_path)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to canonicalize image blob path {:?}", image_path)
+                    })?;
+
+            let metadata_output = tokio::process::Command::new(&self.config.qemu.qemu_img_binary)
+                .arg("info")
+                .arg("--format=qcow2")
+                .arg("--output=json")
+                .arg("--")
+                .arg(&image_path_canon)
+                .output()
+                .await
+                .map_err(|e| anyhow::Error::from(e))
+                .and_then(|output| {
+                    // Ideally we'd want to use the nightly `exit_ok()` here:
+                    if !output.status.success() {
+                        bail!(
+                            "Running qemu-img failed with exit-code {:?}",
+                            output.status.code()
+                        );
+                    }
+
+                    // Don't care about stderr:
+                    Ok(output.stdout)
+                })
+                .with_context(|| format!("Failed to query image metadata for {:?}", image_path))?;
+
+            let metadata: QemuImgMetadata =
+                serde_json::from_slice(&metadata_output).with_context(|| {
+                    format!(
+                        "Failed to parse `qemu-img info` output for {:?}: {:?}",
+                        image_path,
+                        String::from_utf8_lossy(&metadata_output),
+                    )
+                })?;
+
+            top_image.get_or_insert_with(|| (image_path_canon.clone(), metadata.clone()));
+
+            // Make sure that the image has just one child, and that child's
+            // filename is identical to the top-level filename. We do this as a
+            // precaution to images referencing other paths on our machine.
+            if metadata.children.len() != 1 || metadata.children[0].info.children.len() != 0 {
+                bail!(
+                    "Image file {:?} does not have exactly one (recursive) child in qemu-img output",
+                    image_path
+                );
+            }
+
+            let child = &metadata.children[0];
+            if child.info.filename != metadata.filename {
+                bail!(
+                    "Image file {:?}'s child filename ({:?}) diverges from \
+		     main filename ({:?})",
+                    image_path,
+                    &child.info.filename,
+                    &metadata.filename
+                );
+            }
+
+            // Ensure that the image's advertised virtual size is identical to
+            // what we hold in the manifest:
+            let blob_virtual_size: u64 = blob_spec
+                .attrs
+                .get("org.tockos.treadmill.image.qemu_layered_v0.blob-virtual-size")
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Image blob {} missing `blob-virtual-size` attribute",
+                        current_image
+                    )
+                })
+                .and_then(|size_bytes_str| {
+                    u64::from_str_radix(size_bytes_str, 10).with_context(|| {
+                        format!(
+                            "Parsing blob {}'s blob-virtual-size attribute as u64",
+                            current_image
+                        )
+                    })
+                })?;
+            if blob_virtual_size != metadata.virtual_size {
+                bail!(
+                    "Image file {:?}'s virtual size ({} byte) diverges from \
+		     manifest ({} byte)",
+                    image_path,
+                    metadata.virtual_size,
+                    blob_virtual_size,
+                );
+            }
+
+            // The image must not be encrypted:
+            if metadata.encrypted.unwrap_or(false) {
+                bail!("Image file {:?} is encrypted", image_path,);
+            }
+
+            // If the image has a backing format, it must be "qcow2":
+            if let Some(fmt) = metadata.backing_filename_format {
+                if fmt != "qcow2" {
+                    bail!(
+                        "Image file {:?} can only have backing files of \
+			 qcow2 format (actual: {})",
+                        image_path,
+                        fmt,
+                    );
+                }
+            }
+
+            // If the manifest has a `lower` attribute then this image must have
+            // a backing file attribute that's part of our image store, and the
+            // qcow2 image's backing file path must resolve to the same file as
+            // our image store lookup.
+            //
+            // If the manifest doesn't have a `lower` attribute, then the qcow2
+            // file may not have either `full_backing_filename` nor a
+            // `backing_filename`:
+            let blob_lower_opt = blob_spec
+                .attrs
+                .get("org.tockos.treadmill.image.qemu_layered_v0.lower");
+            if let Some(blob_lower) = blob_lower_opt {
+                // We do have a lower blob, look it up in the image store:
+                let lower_blob_spec = manifest.blobs.get(blob_lower).ok_or_else(|| {
+                    anyhow!(
+                        "Image missing blob {}, referenced by blob {}",
+                        blob_lower,
+                        current_image
+                    )
+                })?;
+
+                let image_store_path = self
+                    .image_store_client
+                    .blob_path(&lower_blob_spec.sha256_digest)
+                    .await;
+
+                let image_store_path_canon = tokio::fs::canonicalize(&image_store_path)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to canonicalize image blob path {:?},
+                             returned by image store lookup for blob {}",
+                            image_store_path, blob_lower,
+                        )
+                    })?;
+
+                let full_backing_filename_canon = if let Some(f) = &metadata.full_backing_filename {
+                    tokio::fs::canonicalize(f).await.with_context(|| {
+                        format!(
+                            "Failed to canonicalize image blob path {:?},
+                                     referenced by qcow image file {}",
+                            f, current_image,
+                        )
+                    })?
+                } else {
+                    bail!(
+                        "Image {} supposed to reference blob {}, but \
+			     qemu-img references no backing file",
+                        current_image,
+                        blob_lower,
+                    );
+                };
+
+                // Ensure that the canonical path representations for the
+                // `image_path` and the path in the image metadata are
+                // identical:
+                if image_store_path_canon != full_backing_filename_canon {
+                    bail!(
+                        "Image blob {} maps this path in the image store: \
+			 {:?}, but qcow2 of layer {} maps to {:?} as a \
+			 backing file instead.",
+                        blob_lower,
+                        image_store_path_canon,
+                        current_image,
+                        full_backing_filename_canon,
+                    );
+                }
+
+                // All checks passed, continue with the next layer:
+                current_image = blob_lower;
+            } else {
+                // Image is not supported to have any lower / backing layer:
+                if metadata.backing_filename.is_some() || metadata.full_backing_filename.is_some() {
+                    bail!(
+                        "Image blob {} (file {:?}) does not have a \
+			 lower-blob specified by references a backing file",
+                        current_image,
+                        image_path_canon,
+                    );
+                }
+
+                // We've reached the end of the image chain without error, break
+                // out of the loop.
+                break;
+            }
+        }
+
+        // If we reach this point, we must have a path to the top
+        // layer of the image. Return it:
+        Ok(top_image.unwrap())
+    }
+
+    async fn start_job_parse_manifest_allocate_disk(
+        &self,
+        start_job_req: &connector::StartJobMessage,
+        top_image_path: &Path,
+        top_image_qemu_info: &QemuImgMetadata,
+    ) -> Result<PathBuf, connector::JobError> {
+        // Ensure that the state/jobs directory (and all recursive parents)
+        // exists:
+        let jobs_dir = self.config.qemu.state_dir.join("jobs");
+        tokio::fs::create_dir_all(&jobs_dir).await.unwrap();
+
+        // Create a new working directory for this job:
+        let job_dir = jobs_dir.join(&start_job_req.job_id.to_string());
+        match tokio::fs::create_dir(&job_dir).await {
+            Ok(()) => (),
+
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(connector::JobError {
+                    error_kind: connector::JobErrorKind::JobAlreadyExists,
+                    description: format!(
+                        "A job with {:?} was previously started on this supervisor",
+                        start_job_req.job_id,
+                    ),
+                });
+            }
+
+            Err(e) => {
+                // TODO: avoid panics
+                panic!("Cannot create job directory {:?}: {:?}", job_dir, e);
+            }
+        };
+
+        // Create a new thin-provisioned disk image with the specified size. The
+        // virtual machine image can then be expanded.
+        //
+        // We want to make sure that the new CoW disk image layer is not smaller
+        // than the one specified in the manifest for the image.
+        if top_image_qemu_info.virtual_size > self.config.qemu.working_disk_max_bytes {
+            return Err(connector::JobError {
+                error_kind: connector::JobErrorKind::JobAlreadyExists,
+                description: format!(
+                    "A job with {:?} was previously started on this supervisor",
+                    start_job_req.job_id,
+                ),
+            });
+        }
+
+        // Create the disk, based on the top image layer:
+        let disk_image_file = job_dir.join("disk.qcow2");
+        tokio::process::Command::new(&self.config.qemu.qemu_img_binary)
+            .arg("create")
+            // Image format:
+            .arg("-f")
+            .arg("qcow2")
+            // Backing file format:
+            .arg("-F")
+            .arg("qcow2")
+            // Backing file:
+            .arg("-b")
+            .arg(&top_image_path)
+            // New image file:
+            .arg(&disk_image_file)
+            // New image size (in bytes, without suffix):
+            .arg(&self.config.qemu.working_disk_max_bytes.to_string())
+            .output()
+            .await
+            .map_err(|e| anyhow::Error::from(e))
+            .and_then(|output| {
+                // Ideally we'd want to use the nightly `exit_ok()` here:
+                if !output.status.success() {
+                    bail!(
+                        "Running qemu-img failed with exit-code {:?}, stdout: {:?}, stderr: {:?}",
+                        output.status.code(),
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr),
+                    );
+                }
+
+                // Don't care about stdout or stderr in the success case:
+                Ok(())
+            })
+            .map_err(|e| connector::JobError {
+                error_kind: connector::JobErrorKind::InternalError,
+                description: format!(
+                    "Failed to allocate disk image for job {:?}: {:?}",
+                    start_job_req.job_id, e,
+                ),
+            })?;
+
+        Ok(disk_image_file)
+    }
+
+    async fn start_job_cont(this: &Arc<Self>, job_id: Uuid) {
+        // Obtain a reference to the job. It's possible for the job to have
+        // transitioned from `ImageFetched` to any other state in between
+        // `fetch_image` releasing its lock and this function executing, so if
+        // the job is no longer alive or in the `ImageFetched` state, return.
+        let job_opt = {
+            // Do not hold onto the global job's lock:
+            this.jobs.lock().await.get(&job_id).cloned()
+        };
+
+        // If the job is no longer alive, return:
+        let job = match job_opt {
+            Some(job) => job,
+            None => {
+                // This case should be pretty rare but does not indicate a bug
+                // per se, so let's issue a debug message just in case:
+                debug!(
+                    "Job {:?} vanished before `start_job_cont` could acquire its lock",
+                    job_id
+                );
+                return;
+            }
+        };
+
+        // Acquire a lock on the job:
+        let mut job_lg = job.lock().await;
+
+        // We swap in a state of `Starting` temporarily to please the Rust
+        // borrow checker. Before we leave this function, we must replace this
+        // state again!
+        //
+        // If the job is in any state other than `ImageFetched`, swap back and
+        // return immediately:
+        let QemuSupervisorImageFetchedState {
+            start_job_req,
+            image_id,
+            manifest,
+        } = match std::mem::replace(&mut *job_lg, QemuSupervisorJobState::Starting) {
+            QemuSupervisorJobState::ImageFetched(state) => state,
+            prev_state => {
+                // Swap the old state back:
+                *job_lg = prev_state;
+
+                // Same as above, let's issue a debug message:
+                debug!(
+                    "Job {:?} changed state before `start_job_cont` could \
+			 aquire a lock: {:?}",
+                    job_id, job,
+                );
+
+                return;
+            }
+        };
+
+        // Inform the connector that we're now preparing for start:
+        this.connector
+            .update_job_state(
+                start_job_req.job_id,
+                connector::JobState::Starting {
+                    stage: connector::JobStartingStage::Allocating,
+                    status_message: None,
+                },
+            )
+            .await;
+
+        // Parse the manifest and sanity-check all image layers. We do this in
+        // an async block such that we can use the `?` operator:
+        let (top_image_path, top_image_qemu_info) =
+            match this.start_job_parse_manifest_check_images(&manifest).await {
+                Ok(v) => v,
+
+                Err(e) => {
+                    // Image is invalid, report an error:
+                    this.connector
+                        .report_job_error(
+                            start_job_req.job_id,
+                            connector::JobError {
+                                error_kind: connector::JobErrorKind::ImageInvalid,
+                                description: format!(
+                                    "Validation of image {:?} failed: {:?}",
+                                    image_id, e
+                                ),
+                            },
+                        )
+                        .await;
+
+                    // No resources have been allocated (yet), so simply remove the
+                    // job and set its state to `Stopping`, in case anyone else has
+                    // a reference to it still.
+                    //
+                    // Safe to call, we don't hold a lock on `this.jobs`:
+                    this.remove_job(job_id).await;
+
+                    // Prevent other tasks from further advancing this job's state:
+                    *job_lg = QemuSupervisorJobState::Stopping;
+
+                    return;
+                }
+            };
+
+        // Allocate the job's disk:
+        let job_disk_image_path = match this
+            .start_job_parse_manifest_allocate_disk(
+                &start_job_req,
+                &top_image_path,
+                &top_image_qemu_info,
+            )
+            .await
+        {
+            Ok(v) => v,
+
+            Err(job_error) => {
+                // Image is invalid, report an error:
+                this.connector
+                    .report_job_error(start_job_req.job_id, job_error)
+                    .await;
+
+                // No resources have been allocated (yet), so simply remove the
+                // job and set its state to `Stopping`, in case anyone else has
+                // a reference to it still.
+                //
+                // Safe to call, we don't hold a lock on `this.jobs`:
+                this.remove_job(job_id).await;
+
+                // Prevent other tasks from further advancing this job's state:
+                *job_lg = QemuSupervisorJobState::Stopping;
+
+                return;
+            }
+        };
+
+        // Template the QEMU arguments:
+        let mut qemu_arg_substs: HashMap<String, String> = HashMap::new();
+        assert!(qemu_arg_substs
+            .insert("job_id".to_string(), start_job_req.job_id.to_string())
+            .is_none());
+        assert!(qemu_arg_substs
+            .insert(
+                "main_disk_image".to_string(),
+                job_disk_image_path.display().to_string()
+            )
+            .is_none());
+
+        let qemu_args = match this
+            .config
+            .qemu
+            .qemu_args
+            .iter()
+            .map(|argstr| strfmt::strfmt(argstr, &qemu_arg_substs))
+            .collect::<Result<Vec<String>, strfmt::FmtError>>()
+        {
+            Ok(templated) => templated,
+
+            Err(format_error) => {
+                // Image is invalid, report an error:
+                this.connector
+                    .report_job_error(
+                        start_job_req.job_id,
+                        connector::JobError {
+                            error_kind: connector::JobErrorKind::InternalError,
+                            description: format!(
+                                "Failed to generate QEMU command line arguments: {:?}",
+                                format_error,
+                            ),
+                        },
+                    )
+                    .await;
+
+                // TODO: remove job resources here.
+
+                // Safe to call, we don't hold a lock on `this.jobs`:
+                this.remove_job(job_id).await;
+
+                // Prevent other tasks from further advancing this job's state:
+                *job_lg = QemuSupervisorJobState::Stopping;
+
+                return;
+            }
+        };
+
+        // Start a TCP control socket on the specified listen addr:
+        let control_socket = TcpControlSocket::new(
+            start_job_req.job_id,
+            this.config.qemu.tcp_control_socket_listen_addr,
+            this.clone(),
+        )
+        .await
+        .unwrap();
+
+        let qemu_proc = tokio::process::Command::new(&this.config.qemu.qemu_binary)
+            .args(&qemu_args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .unwrap();
+
+        // Job has been started, let the coordinator know:
+        this.connector
+            .update_job_state(
+                start_job_req.job_id,
+                connector::JobState::Starting {
+                    // Booting, but puppet has not yet reported "ready":
+                    stage: connector::JobStartingStage::Booting,
+                    status_message: None,
+                },
+            )
+            .await;
+
+        // Mark the job as started:
+        *job_lg = QemuSupervisorJobState::Running(QemuSupervisorJobRunningState {
+            start_job_req,
+            control_socket,
+            qemu_proc,
+        });
+    }
+}
+
+#[async_trait]
+impl connector::Supervisor for QemuSupervisor {
+    async fn start_job(
+        this: &Arc<Self>,
+        start_job_req: connector::StartJobMessage,
+    ) -> Result<(), connector::JobError> {
+        // This method may be long-lived, but we should avoid performing
+        // long-running, uninterruptible actions in here (as this will prevent
+        // other events from being delivered). We're provided an &Arc<Self> to
+        // be able to launch async tasks, while returning immediately. We only
+        // perform sanity checks here and transition into other states that
+        // perform potentially long-running actions.
+
+        // Take a short-lived lock on the global jobs object to check that we're
+        // not asked to double-start a job and whether we can fit another. If
+        // everything's good, insert a job into the HashMap and return its `Arc`
+        // reference. This way we don't hold the global lock for too long.
+        //
+        // We can't use a Rust scope, as we'll want to obtain a lock on the job
+        // itself before releasing the global lock, such that we don't run the
+        // risk of scheduling another action on this job when it's not yet
+        // initialized fully.
+        //
+        // ============ GLOBAL `jobs` HASHMAP LOCK ACQUIRE ==================
+        //
+        let mut jobs_lg = this.jobs.lock().await;
+
+        // Make sure that there's not another job with the same ID executing
+        // currently. Even when we resume a job, it needs to have been
+        // stopped first:
+        if jobs_lg.get(&start_job_req.job_id).is_some() {
+            return Err(connector::JobError {
+                error_kind: connector::JobErrorKind::AlreadyRunning,
+                description: format!(
+                    "Job {:?} is already running and cannot be started again.",
+                    start_job_req.job_id
+                ),
+            });
+        }
+
+        // Don't start more jobs than we're allowed to. Currently, the QEMU
+        // supervisor only supports one job at a time (otherwise we'd need to
+        // reason about IP address assignment from a pool, customizable
+        // parameters for each instance, etc.).
+        if jobs_lg.len() > 1 {
+            return Err(connector::JobError {
+                error_kind: connector::JobErrorKind::MaxConcurrentJobs,
+                description: format!(
+                    "Supervisor {:?} cannot start any more concurrent jobs (running {}, max 1).",
+                    this.config.base.supervisor_id,
+                    jobs_lg.len(),
+                ),
+            });
+        }
+
+        // We're good to create this job, create it in the `Starting` state:
+        let job = Arc::new(Mutex::new(QemuSupervisorJobState::Starting));
+
+        // Acquire a lock on the job. No one else has a reference yet, so this
+        // should succeed immediately:
+        let mut job_lg = job.lock().await;
+
+        // Insert a clone of the Arc into the HashMap:
+        jobs_lg.insert(start_job_req.job_id, job.clone());
+
+        // Release the global lock here:
+        std::mem::drop(jobs_lg);
+        //
+        // ========== GLOBAL `jobs` HASHMAP LOCK RELEASED ======================
+
+        // The job was inserted into the `jobs` HashMap and initialized as
+        // `Starting`, let the coordinator know:
+        this.connector
+            .update_job_state(
+                start_job_req.job_id,
+                connector::JobState::Starting {
+                    // Generic starting stage. We don't fetch, allocate or provision any
+                    // resources right now, so report a generic state instead:
+                    stage: connector::JobStartingStage::Starting,
+                    status_message: None,
+                },
+            )
+            .await;
+
+        // Fetch the requested image.
+        //
+        // We avoid locking the job's state for long periods of time, e.g., to
+        // allow cancelling it before the image has been fully fetched.  Thus,
+        // we poll the image supervisor repeatedly, but don't hold onto the
+        // job's lock in between these polling operations.
+
+        let image_id = match start_job_req.init_spec {
+            JobInitSpec::Image { image_id } => image_id,
+            unsupported_init_spec => {
+                unimplemented!("Unsupported init spec: {:?}", unsupported_init_spec)
+            }
+        };
+
+        // Put the job into the `FetchingImage` state:
+        let job_id = start_job_req.job_id; // Copy required below
+        *job_lg = QemuSupervisorJobState::FetchingImage(QemuSupervisorFetchingImageState {
+            start_job_req,
+            image_id,
+            // Will be set to Some(...) when an asynchronous fetch operation is
+            // kicked off:
+            poll_task: None,
+        });
+
+        // Release our lock on the job and hand over to the fetch image method:
+        std::mem::drop(job_lg);
+        Self::fetch_image(this, job_id).await;
+
+        Ok(())
+    }
+
+    async fn stop_job(
+        this: &Arc<Self>,
+        msg: connector::StopJobMessage,
+    ) -> Result<(), connector::JobError> {
+        // We do not immediately remove the job from the global jobs HashMap, as
+        // we want to deallocate all resources before a job with an identical ID
+        // can be resumed again. Thus, first transition it into a `Stopping`
+        // state and return a reference to it. We take ownership of the old job
+        // state and destruct it.
+
+        // Get a reference to this job by an emphemeral lock on `jobs` HashMap:
+        let job: Arc<Mutex<QemuSupervisorJobState>> = {
+            this.jobs
+                .lock()
+                .await
+                .get(&msg.job_id)
+                .cloned()
+                .ok_or(connector::JobError {
+                    error_kind: connector::JobErrorKind::JobNotFound,
+                    description: format!("Job {:?} not found, cannot stop.", msg.job_id),
+                })?
+        };
+
+        let mut job_lg = job.lock().await;
+
+        enum StopJobPrevState {
+            FetchingImage(QemuSupervisorFetchingImageState),
+            ImageFetched(QemuSupervisorImageFetchedState),
+            Running(QemuSupervisorJobRunningState),
+        }
+
+        // Make sure the job is in a state in which we can stop it. If so, place
+        // it into the `Stopping` state.
+        let prev_job_state = match std::mem::replace(&mut *job_lg, QemuSupervisorJobState::Stopping)
+        {
+            // Stoppable states:
+            QemuSupervisorJobState::FetchingImage(s) => StopJobPrevState::FetchingImage(s),
+            QemuSupervisorJobState::ImageFetched(s) => StopJobPrevState::ImageFetched(s),
+            QemuSupervisorJobState::Running(s) => StopJobPrevState::Running(s),
+
+            prev_state @ QemuSupervisorJobState::Starting => {
+                // Put back the previous state:
+                *job_lg = prev_state;
+
+                // We must never be able to acquire a lock over a job in
+                // this state. The job will atomically transition from
+                // `Starting` to some other state in the implementation of
+                // `start_job`. This state is just a placeholder in the
+                // global jobs map, such that no other job with the same ID
+                // can be started:
+                unreachable!("Job must not be in `Starting` state!");
+            }
+
+            prev_state @ QemuSupervisorJobState::Stopping => {
+                // Put back the previous state:
+                *job_lg = prev_state;
+
+                return Err(connector::JobError {
+                    error_kind: connector::JobErrorKind::AlreadyStopping,
+                    description: format!("Job {:?} is already stopping.", msg.job_id),
+                });
+            }
+        };
+
+        // Job is stopping, let the coordinator know:
+        this.connector
+            .update_job_state(
+                msg.job_id,
+                connector::JobState::Stopping {
+                    status_message: None,
+                },
+            )
+            .await;
+
+        // Perform actions depending on the previous job state:
+        match prev_job_state {
+            StopJobPrevState::FetchingImage(QemuSupervisorFetchingImageState {
+                start_job_req: _,
+                image_id: _,
+                poll_task,
+            }) => {
+                // Make sure that we don't have another poll task
+                // scheduled. This is potentially racy, where this abort() call
+                // can come right after an invocation of `Self::fetch_image` has
+                // been scheduled. However, that function will not do anything,
+                // given the job state is now `Stopping` instead of
+                // `FetchingImage`:
+                if let Some(handle) = poll_task {
+                    handle.abort();
+                }
+            }
+
+            StopJobPrevState::ImageFetched(QemuSupervisorImageFetchedState {
+                start_job_req: _,
+                image_id: _,
+                manifest: _,
+            }) => {
+                // Nothing to do, the only time we're seeing this state is in
+                // between fetching image, and actually starting the job. Given
+                // that we've acquired the lock between those two functions, we
+                // don't need to deallocate, shut down or abort anything.
+            }
+
+            StopJobPrevState::Running(QemuSupervisorJobRunningState {
+                start_job_req: _,
+                control_socket,
+                mut qemu_proc,
+            }) => {
+                // TODO: kindly request the puppet to shut down. Here we simply
+                // force it to quit (by using a SIGKILL). This is not nice.
+                qemu_proc.kill().await.unwrap();
+
+                // Shut down the control socket server:
+                control_socket.shutdown().await.unwrap();
+            }
+        }
+
+        // Job has been stopped, let the coordinator know:
+        this.connector
+            .update_job_state(
+                msg.job_id,
+                connector::JobState::Finished {
+                    status_message: None,
+                },
+            )
+            .await;
+
+        // Finally, remove the job from the jobs HashMap. Eventually, all other
+        // `Arc` references (including the one we hold) will get dropped.
+        assert!(this.jobs.lock().await.remove(&msg.job_id).is_some());
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl control_socket::Supervisor for QemuSupervisor {
+    async fn ssh_keys(&self, tgt_job_id: Uuid) -> Option<Vec<String>> {
+        match self.jobs.lock().await.get(&tgt_job_id) {
+            Some(job_state) => match &*job_state.lock().await {
+                // We don't actually store any SSH keys for the QemuSupervisor
+                // job, so just return an empty set:
+                QemuSupervisorJobState::Running(_) => Some(vec![]),
+
+                // Only respond to host / puppet requests when the job is marked
+                // as "running":
+                state => {
+                    warn!(
+                        "Received puppet SSH keys request for job {:?} in invalid state: {}",
+                        tgt_job_id,
+                        state.state_name()
+                    );
+                    None
+                }
+            },
+
+            // Job not found:
+            None => {
+                warn!(
+                    "Received puppet SSH keys request for non-existant job: {:?}",
+                    tgt_job_id
+                );
+                None
+            }
+        }
+    }
+
+    async fn network_config(
+        &self,
+        tgt_job_id: Uuid,
+    ) -> Option<treadmill_rs::api::supervisor_puppet::NetworkConfig> {
+        match self.jobs.lock().await.get(&tgt_job_id) {
+            Some(job_state) => match &*job_state.lock().await {
+                // Job is currently running, respond with its assigned hostname:
+                QemuSupervisorJobState::Running(_) => {
+                    let hostname = format!("job-{}", format!("{}", tgt_job_id).split_at(10).0);
+                    Some(treadmill_rs::api::supervisor_puppet::NetworkConfig {
+                        hostname,
+                        // QemuSupervisor, don't supply a network interface to configure:
+                        interface: None,
+                        ipv4: None,
+                        ipv6: None,
+                    })
+                }
+
+                // Only respond to host / puppet requests when the job is marked
+                // as "running":
+                state => {
+                    warn!(
+                        "Received puppet network config request for job {:?} in invalid state: {}",
+                        tgt_job_id,
+                        state.state_name()
+                    );
+                    None
+                }
+            },
+
+            // Job not found:
+            None => {
+                warn!(
+                    "Received puppet network config request for non-existant job: {:?}",
+                    tgt_job_id
+                );
+                None
+            }
+        }
+    }
+
+    async fn parameters(
+        &self,
+        tgt_job_id: Uuid,
+    ) -> Option<HashMap<String, treadmill_rs::api::supervisor_puppet::ParameterValue>> {
+        match self.jobs.lock().await.get(&tgt_job_id) {
+            Some(job_state) => match &*job_state.lock().await {
+                // Job is currently running:
+                QemuSupervisorJobState::Running(QemuSupervisorJobRunningState {
+                    start_job_req,
+                    ..
+                }) => Some(start_job_req.parameters.clone()),
+
+                // Only respond to host / puppet requests when the job is marked
+                // as "running":
+                state => {
+                    warn!(
+                        "Received puppet parameters request for job {:?} in invalid state: {}",
+                        tgt_job_id,
+                        state.state_name()
+                    );
+                    None
+                }
+            },
+
+            // Job not found:
+            None => {
+                warn!(
+                    "Received puppet parameters request for non-existant job: {:?}",
+                    tgt_job_id
+                );
+                None
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    use simplelog::{self, ColorChoice, LevelFilter, TermLogger, TerminalMode};
+    use treadmill_rs::connector::SupervisorConnector;
+
+    TermLogger::init(
+        LevelFilter::Debug,
+        simplelog::ConfigBuilder::new()
+            .set_target_level(LevelFilter::Debug)
+            .build(),
+        TerminalMode::Mixed,
+        ColorChoice::Auto,
+    )
+    .unwrap();
+    info!("Treadmill Qemu Supervisor, Hello World!");
+
+    let args = QemuSupervisorArgs::parse();
+
+    let config_str = std::fs::read_to_string(&args.config_file).unwrap();
+    let config: QemuSupervisorConfig = toml::from_str(&config_str).unwrap();
+
+    let image_store =
+        image_store_client::ImageStoreClient::new(config.image_store.http_endpoint.clone())
+            .await
+            .unwrap()
+            .into_local(&config.image_store.fs_endpoint)
+            .await
+            .unwrap();
+
+    match config.base.coord_connector {
+        SupervisorCoordConnector::CliConnector => {
+            let cli_connector_config = config.cli_connector.clone().ok_or(anyhow!(
+                "Requested CliConnector, but `cli_connector` config not present."
+            ))?;
+
+            // Both the supervisor and connectors have references to each other,
+            // so we break the cyclic dependency with an initially unoccupied
+            // weak Arc reference:
+            let mut connector_opt = None;
+
+            let qemu_supervisor = {
+                // Shadow, to avoid moving the variable:
+                let connector_opt = &mut connector_opt;
+                Arc::new_cyclic(move |weak_supervisor| {
+                    let connector = Arc::new(tml_cli_connector::CliConnector::new(
+                        config.base.supervisor_id,
+                        cli_connector_config,
+                        weak_supervisor.clone(),
+                    ));
+                    *connector_opt = Some(connector.clone());
+                    QemuSupervisor::new(connector, image_store, args, config)
+                })
+            };
+
+            let connector = connector_opt.take().unwrap();
+
+            connector.run().await;
+
+            // Must drop qemu_supervisor reference _after_ connector.run(), as
+            // that'll upgrade its Weak into an Arc. Otherwise we're dropping
+            // the only reference to it:
+            std::mem::drop(qemu_supervisor);
+
+            Ok(())
+        }
+        SupervisorCoordConnector::WsConnector => {
+            let ws_connector_config = config.ws_connector.clone().ok_or(anyhow!(
+                "Requested WsConnector, but `ws_connector` config not present."
+            ))?;
+
+            // Both the supervisor and connectors have references to each other,
+            // so we break the cyclic dependency with an initially unoccupied
+            // weak Arc reference:
+            let mut connector_opt = None;
+
+            let qemu_supervisor = {
+                // Shadow, to avoid moving the variable:
+                let connector_opt = &mut connector_opt;
+                Arc::new_cyclic(move |weak_supervisor| {
+                    let connector = Arc::new(tml_ws_connector::WsConnector::new(
+                        config.base.supervisor_id,
+                        ws_connector_config,
+                        weak_supervisor.clone(),
+                    ));
+                    *connector_opt = Some(connector.clone());
+                    QemuSupervisor::new(connector, image_store, args, config)
+                })
+            };
+
+            let connector = connector_opt.take().unwrap();
+
+            connector.run().await;
+
+            drop(qemu_supervisor);
+
+            Ok(())
+        }
+        unsupported_connector => {
+            bail!("Unsupported coord connector: {:?}", unsupported_connector);
+        }
+    }
+}

--- a/treadmill-rs/Cargo.toml
+++ b/treadmill-rs/Cargo.toml
@@ -15,3 +15,4 @@ subtle = "2.6.1"
 chrono = { version = "0.4.38", features = ["serde"] }
 #humantime-serde = "1.1.1"
 fundu = { version = "2.0.0", features = ["chrono", "serde"] }
+

--- a/treadmill-rs/src/connector.rs
+++ b/treadmill-rs/src/connector.rs
@@ -17,6 +17,14 @@ pub enum JobErrorKind {
     /// The requested job is already in the process of being shut down.
     AlreadyStopping,
 
+    /// A job with this ID was previously running on this supervisor,
+    /// but we weren't asked to `resume` it.
+    JobAlreadyExists,
+
+    /// Cannot resume this job, either because this functionality is
+    /// unsupported or because this particular job cannot be resumed.
+    CannotResume,
+
     /// Job with the specified ID cannot be found.
     JobNotFound,
 
@@ -27,9 +35,15 @@ pub enum JobErrorKind {
     /// resource stated therein cannot be fetched):
     ImageNotFound,
 
+    /// There is some problem with the image.
+    ImageInvalid,
+
     /// The image is not compatible with, or does not meet the
     /// expectations of this supervisor.
     ImageNotCompatible,
+
+    /// Internal error within the supervisor:
+    InternalError,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This adds an initial, work-in-progress QEMU supervisor to start virtual machine-backed jobs.

It contains more general logic for dealing with QCOW2 images, an initial image manifest file format specification, and scaffolding for an image store client. Those components may need to be split out into individual crates or the common `treadmill-rs` crate later.

The code in this commit is enough to be able to start and stop a virtual machine based on an image located in the image store, by using the connector API.
