### PR TITLE
dev/switchboard: Fix job parameter insertion SQL query.

### DIFF
--- a/.sqlx/query-846747f9007cfa1faf02c7a595734be025f68079b8f71d70cd9e0f7e4d8565fd.json
+++ b/.sqlx/query-846747f9007cfa1faf02c7a595734be025f68079b8f71d70cd9e0f7e4d8565fd.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        INSERT INTO job_parameters (job_id, key, value)\n            SELECT $1, keys, values\n            FROM UNNEST($2::text[]) as keys,\n                 UNNEST($3::parameter_value[]) as values\n        ;\n        ",
+  "query": "INSERT INTO job_parameters (job_id, key, value)\n                SELECT $1, (c_rec).unnest, row((c_rec).value, (c_rec).secret)::parameter_value\n                FROM UNNEST($2::text[], $3::parameter_value[]) as c_rec;\n            ",
   "describe": {
     "columns": [],
     "parameters": {
@@ -35,5 +35,5 @@
     },
     "nullable": []
   },
-  "hash": "fc41eef879e58777df13ea01e2aa17dbd784a4e8e42b58642270b09360135bf6"
+  "hash": "846747f9007cfa1faf02c7a595734be025f68079b8f71d70cd9e0f7e4d8565fd"
 }

--- a/switchboard/switchboard/src/model/job.rs
+++ b/switchboard/switchboard/src/model/job.rs
@@ -255,7 +255,6 @@ pub mod params {
     ) -> Result<(), sqlx::Error> {
         // https://github.com/launchbadge/sqlx/blob/main/FAQ.md#how-can-i-bind-an-array-to-a-values-clause-how-can-i-do-bulk-inserts
         let (keys, values): (Vec<String>, Vec<ParameterValue>) = items.into_iter().unzip();
-        tracing::info!("keys={keys:?}; values={values:?}");
         let values: Vec<SqlParamValue> = values
             .into_iter()
             .map(|ParameterValue { value, secret }| SqlParamValue { value, secret })


### PR DESCRIPTION
Bugfix for CI issues noted in #36. Query was inserting all parameter keys paired with all parameter values (instead of all parameter keys, each with their own value), which created violations of the primary key constraint.
The query has been rewritten and tested.
As this was an issue at the SQL level that could not be caught anywhere higher, no additional validation has been added.