### PR TITLE
connector/ws: allow reading token from file in addition to config

### DIFF
--- a/connector/ws/Cargo.toml
+++ b/connector/ws/Cargo.toml
@@ -10,7 +10,7 @@ treadmill-rs = { path = "../../treadmill-rs" }
 uuid = { version = "1.9.1", features = ["v4", "rng"] }
 chrono = "0.4.38"
 
-tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros", "sync", "fs"] }
 tokio-tungstenite = { version = "0.23.1", features = ["rustls-tls-native-roots"] }
 base64 = "0.22.1"
 futures-util = { version = "0.3.30", features = ["sink"] }


### PR DESCRIPTION
This makes it easier to exclude secrets from otherwise public configuration files.