### PR TITLE
switchboard: add all-capable "admin" permission

### DIFF
--- a/switchboard/src/auth/db.rs
+++ b/switchboard/src/auth/db.rs
@@ -33,7 +33,9 @@ impl PermissionQueryExecutor for DbPermSearcher {
                 Ok(v) => v,
                 Err(e) => return PermissionResult::unauthorized(AuthorizationError::Database(e)),
             };
-            perms.iter().any(|r| r.permission == perm_str)
+            perms
+                .iter()
+                .any(|r| r.permission == "admin" || r.permission == perm_str)
         } else {
             let perms = match sqlx::query!(
                 r#"select token_id,permission from tml_switchboard.api_token_privileges where token_id = $1;"#,
@@ -47,7 +49,9 @@ impl PermissionQueryExecutor for DbPermSearcher {
                     return PermissionResult::unauthorized(AuthorizationError::Database(e));
                 }
             };
-            perms.iter().any(|r| r.permission == perm_str)
+            perms
+                .iter()
+                .any(|r| r.permission == "admin" || r.permission == perm_str)
         };
 
         if ok {


### PR DESCRIPTION
This partially addresses https://github.com/treadmill-tb/treadmill/issues/63 by creating an all-capable admin permission which we can assign to system administrators.

It also allows us to roll this system out among an initial set of fully trusted users while we are revisiting the permissions system.
