### PR TITLE
Unify crate name prefix to "treadmill-"

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -40,10 +40,10 @@ jobs:
           PGPASSWORD: ${{ env.POSTGRES_PASSWORD }}
       - name: Build components
         run: |
-          cargo build --package tml-switchboard
-          cargo build --package tml-mock-supervisor
-          cargo build --package tml-puppet
-          cargo build --package tml-cli
+          cargo build --package treadmill-switchboard
+          cargo build --package treadmill-mock-supervisor
+          cargo build --package treadmill-puppet
+          cargo build --package treadmill-cli
           cp ./target/debug/tml ./tml
         env:
           DATABASE_URL: postgres://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@127.0.0.1:5432/${{ env.POSTGRES_DB }}
@@ -57,15 +57,15 @@ jobs:
       - name: Start switchboard
         run: |
           export RUST_LOG=debug,sqlx=info
-          cargo run --package tml-switchboard -- serve -c switchboard_config.toml > switchboard.log &
+          cargo run --package treadmill-switchboard -- serve -c switchboard_config.toml > switchboard.log &
           echo $! > switchboard.pid
           sleep 3
         env:
           TML__DATABASE__AUTH__PASSWORD: ${{ env.POSTGRES_PASSWORD }}
       - name: Start mock supervisor
         run: |
-          cargo build --package tml-puppet
-          nohup cargo run --package tml-mock-supervisor -- -c mock_supervisor_config.toml --puppet-binary ./target/debug/tml-puppet > mock_supervisor.log 2>&1 &
+          cargo build --package treadmill-puppet
+          nohup cargo run --package treadmill-mock-supervisor -- -c mock_supervisor_config.toml --puppet-binary ./target/debug/tml-puppet > mock_supervisor.log 2>&1 &
           echo $! > mock_supervisor.pid
           sleep 3
       - name: Check mock supervisor log

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,9 +47,9 @@ jobs:
           PGPASSWORD: ${{ env.POSTGRES_PASSWORD }}
       - name: Build components
         run: |
-          cargo build --package tml-switchboard
-          cargo build --package tml-mock-supervisor
-          cargo build --package tml-puppet
+          cargo build --package treadmill-switchboard
+          cargo build --package treadmill-mock-supervisor
+          cargo build --package treadmill-puppet
       - name: Generate test configurations
         run: |
           cp switchboard/config.example.toml switchboard_config.toml
@@ -66,13 +66,13 @@ jobs:
       - name: Start switchboard
         run: |
           export RUST_LOG=debug
-          cargo run --package tml-switchboard -- serve -c switchboard_config.toml > switchboard.log 2>&1 &
+          cargo run --package treadmill-switchboard -- serve -c switchboard_config.toml > switchboard.log 2>&1 &
           echo $! > switchboard.pid
           sleep 1
       - name: Start mock supervisor
         run: |
-          cargo build --package tml-puppet
-          nohup cargo run --package tml-mock-supervisor -- -c mock_supervisor_config.toml --puppet-binary ./target/debug/tml-puppet > mock_supervisor.log 2>&1 &
+          cargo build --package treadmill-puppet
+          nohup cargo run --package treadmill-mock-supervisor -- -c mock_supervisor_config.toml --puppet-binary ./target/debug/treadmill-puppet > mock_supervisor.log 2>&1 &
           echo $! > mock_supervisor.pid
           sleep 1
       - name: Check mock supervisor log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,223 +4024,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tml-cli"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "chrono",
- "clap 2.34.0",
- "dirs",
- "env_logger",
- "hex",
- "log",
- "reqwest",
- "serde",
- "serde_json",
- "ssh2",
- "tokio",
- "toml 0.5.11",
- "treadmill-rs",
- "uuid",
- "xdg",
-]
-
-[[package]]
-name = "tml-cli-connector"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "hex",
- "inquire",
- "log",
- "serde",
- "tokio",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
-name = "tml-mock-supervisor"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap 4.5.16",
- "serde",
- "tml-cli-connector",
- "tml-tcp-control-socket-server",
- "tml-ws-connector",
- "tokio",
- "toml 0.8.19",
- "tracing",
- "tracing-subscriber",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
-name = "tml-nbd-netboot-supervisor"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-recursion",
- "async-trait",
- "clap 4.5.16",
- "serde",
- "serde_json",
- "strfmt",
- "tml-cli-connector",
- "tml-supervisor-lib",
- "tml-tcp-control-socket-server",
- "tml-ws-connector",
- "tokio",
- "toml 0.8.19",
- "tracing",
- "tracing-subscriber",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
-name = "tml-puppet"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap 4.5.16",
- "log",
- "nix 0.29.0",
- "sd-notify",
- "simplelog",
- "tml-tcp-control-socket-client",
- "tokio",
- "treadmill-rs",
- "uuid",
- "zbus",
-]
-
-[[package]]
-name = "tml-qemu-supervisor"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-recursion",
- "async-trait",
- "clap 4.5.16",
- "serde",
- "serde_json",
- "strfmt",
- "tml-cli-connector",
- "tml-supervisor-lib",
- "tml-tcp-control-socket-server",
- "tml-ws-connector",
- "tokio",
- "toml 0.8.19",
- "tracing",
- "tracing-subscriber",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
-name = "tml-supervisor-lib"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "serde",
- "tokio",
- "toml 0.8.19",
- "tracing",
- "treadmill-rs",
-]
-
-[[package]]
-name = "tml-switchboard"
-version = "0.1.0"
-dependencies = [
- "argon2",
- "async-trait",
- "axum",
- "axum-extra",
- "axum-server",
- "base64 0.22.1",
- "chrono",
- "clap 4.5.16",
- "console-subscriber",
- "dashmap",
- "figment",
- "futures-util",
- "headers",
- "http 1.1.0",
- "miette",
- "rand 0.9.0-alpha.2",
- "serde",
- "serde_json",
- "sqlx",
- "sqlx-cli",
- "subtle",
- "thiserror",
- "time",
- "tokio",
- "toml 0.8.19",
- "tower-http",
- "tracing",
- "tracing-subscriber",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
-name = "tml-tcp-control-socket-client"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytes",
- "futures",
- "log",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "treadmill-rs",
-]
-
-[[package]]
-name = "tml-tcp-control-socket-server"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytes",
- "futures",
- "log",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
-name = "tml-ws-connector"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "futures-util",
- "rand 0.9.0-alpha.2",
- "rustls",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-tungstenite 0.23.1",
- "tracing",
- "treadmill-rs",
- "uuid",
-]
-
-[[package]]
 name = "tokio"
 version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,6 +4311,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "treadmill-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "chrono",
+ "clap 2.34.0",
+ "dirs",
+ "env_logger",
+ "hex",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "ssh2",
+ "tokio",
+ "toml 0.5.11",
+ "treadmill-rs",
+ "uuid",
+ "xdg",
+]
+
+[[package]]
+name = "treadmill-cli-connector"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "hex",
+ "inquire",
+ "log",
+ "serde",
+ "tokio",
+ "treadmill-rs",
+ "uuid",
+]
+
+[[package]]
+name = "treadmill-mock-supervisor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap 4.5.16",
+ "serde",
+ "tokio",
+ "toml 0.8.19",
+ "tracing",
+ "tracing-subscriber",
+ "treadmill-cli-connector",
+ "treadmill-rs",
+ "treadmill-tcp-control-socket-server",
+ "treadmill-ws-connector",
+ "uuid",
+]
+
+[[package]]
+name = "treadmill-nbd-netboot-supervisor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-recursion",
+ "async-trait",
+ "clap 4.5.16",
+ "serde",
+ "serde_json",
+ "strfmt",
+ "tokio",
+ "toml 0.8.19",
+ "tracing",
+ "tracing-subscriber",
+ "treadmill-cli-connector",
+ "treadmill-rs",
+ "treadmill-supervisor-lib",
+ "treadmill-tcp-control-socket-server",
+ "treadmill-ws-connector",
+ "uuid",
+]
+
+[[package]]
+name = "treadmill-puppet"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 4.5.16",
+ "log",
+ "nix 0.29.0",
+ "sd-notify",
+ "simplelog",
+ "tokio",
+ "treadmill-rs",
+ "treadmill-tcp-control-socket-client",
+ "uuid",
+ "zbus",
+]
+
+[[package]]
+name = "treadmill-qemu-supervisor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-recursion",
+ "async-trait",
+ "clap 4.5.16",
+ "serde",
+ "serde_json",
+ "strfmt",
+ "tokio",
+ "toml 0.8.19",
+ "tracing",
+ "tracing-subscriber",
+ "treadmill-cli-connector",
+ "treadmill-rs",
+ "treadmill-supervisor-lib",
+ "treadmill-tcp-control-socket-server",
+ "treadmill-ws-connector",
+ "uuid",
+]
+
+[[package]]
 name = "treadmill-rs"
 version = "0.1.0"
 dependencies = [
@@ -4540,6 +4442,104 @@ dependencies = [
  "serde_with",
  "subtle",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "treadmill-supervisor-lib"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "tokio",
+ "toml 0.8.19",
+ "tracing",
+ "treadmill-rs",
+]
+
+[[package]]
+name = "treadmill-switchboard"
+version = "0.1.0"
+dependencies = [
+ "argon2",
+ "async-trait",
+ "axum",
+ "axum-extra",
+ "axum-server",
+ "base64 0.22.1",
+ "chrono",
+ "clap 4.5.16",
+ "console-subscriber",
+ "dashmap",
+ "figment",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "miette",
+ "rand 0.9.0-alpha.2",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "sqlx-cli",
+ "subtle",
+ "thiserror",
+ "time",
+ "tokio",
+ "toml 0.8.19",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "treadmill-rs",
+ "uuid",
+]
+
+[[package]]
+name = "treadmill-tcp-control-socket-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "log",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "treadmill-rs",
+]
+
+[[package]]
+name = "treadmill-tcp-control-socket-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "log",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "treadmill-rs",
+ "uuid",
+]
+
+[[package]]
+name = "treadmill-ws-connector"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "futures-util",
+ "rand 0.9.0-alpha.2",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.23.1",
+ "tracing",
+ "treadmill-rs",
  "uuid",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-cli"
+name = "treadmill-cli"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/connector/cli/Cargo.toml
+++ b/connector/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-cli-connector"
+name = "treadmill-cli-connector"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/connector/ws/Cargo.toml
+++ b/connector/ws/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-ws-connector"
+name = "treadmill-ws-connector"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/control-socket/tcp/client/Cargo.toml
+++ b/control-socket/tcp/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-tcp-control-socket-client"
+name = "treadmill-tcp-control-socket-client"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/control-socket/tcp/server/Cargo.toml
+++ b/control-socket/tcp/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-tcp-control-socket-server"
+name = "treadmill-tcp-control-socket-server"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/puppet/Cargo.toml
+++ b/puppet/Cargo.toml
@@ -1,18 +1,22 @@
 [package]
-name = "tml-puppet"
+name = "treadmill-puppet"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "tml-puppet"
+path = "src/main.rs"
+
 [features]
 default = ["transport_tcp"]
 
-transport_tcp = ["tml-tcp-control-socket-client"]
+transport_tcp = ["treadmill-tcp-control-socket-client"]
 
 [dependencies]
 treadmill-rs = { path = "../treadmill-rs" }
 
-tml-tcp-control-socket-client = { path = "../control-socket/tcp/client", optional = true }
+treadmill-tcp-control-socket-client = { path = "../control-socket/tcp/client", optional = true }
 
 uuid = { version = "1.6.1", features = ["serde"] }
 anyhow = "1.0.76"

--- a/puppet/src/control_socket_client.rs
+++ b/puppet/src/control_socket_client.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 // TCP control socket transport implementation:
 #[cfg(feature = "transport_tcp")]
-pub use tml_tcp_control_socket_client as tcp;
+pub use treadmill_tcp_control_socket_client as tcp;
 
 use treadmill_rs::api::supervisor_puppet::{
     NetworkConfig, ParameterValue, PuppetEvent, PuppetReq, SupervisorEvent, SupervisorResp,

--- a/supervisor/lib/Cargo.toml
+++ b/supervisor/lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-supervisor-lib"
+name = "treadmill-supervisor-lib"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/supervisor/mock/Cargo.toml
+++ b/supervisor/mock/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-mock-supervisor"
+name = "treadmill-mock-supervisor"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -9,9 +9,9 @@ edition.workspace = true
 # tml-puppet = { path = "../../puppet", artifact = "bin" }
 
 treadmill-rs = { path = "../../treadmill-rs" }
-tml-tcp-control-socket-server = { path = "../../control-socket/tcp/server" }
-tml-cli-connector = { path = "../../connector/cli" }
-tml-ws-connector = { path = "../../connector/ws" }
+treadmill-tcp-control-socket-server = { path = "../../control-socket/tcp/server" }
+treadmill-cli-connector = { path = "../../connector/cli" }
+treadmill-ws-connector = { path = "../../connector/ws" }
 
 tokio = { version = "1.35.1", default-features = false, features = ["rt-multi-thread", "process", "fs"] }
 toml = "0.8.8"

--- a/supervisor/mock/src/main.rs
+++ b/supervisor/mock/src/main.rs
@@ -17,8 +17,8 @@ use treadmill_rs::supervisor::{SupervisorBaseConfig, SupervisorCoordConnector};
 // TODO: to port!
 // use treadmill_sse_connector::SSEConnector;
 
-use tml_tcp_control_socket_server::TcpControlSocket;
 use treadmill_rs::api::switchboard_supervisor::{SupervisorEvent, SupervisorJobEvent};
+use treadmill_tcp_control_socket_server::TcpControlSocket;
 
 #[derive(Parser, Debug, Clone)]
 pub struct MockSupervisorArgs {
@@ -58,9 +58,9 @@ pub struct MockSupervisorConfig {
 
     /// Configurations for individual connector implementations. All are
     /// optional, and not all of them have to be supported:
-    cli_connector: Option<tml_cli_connector::CliConnectorConfig>,
+    cli_connector: Option<treadmill_cli_connector::CliConnectorConfig>,
 
-    ws_connector: Option<tml_ws_connector::WsConnectorConfig>,
+    ws_connector: Option<treadmill_ws_connector::WsConnectorConfig>,
 
     mock: MockConfig,
 }
@@ -655,7 +655,7 @@ async fn main() -> Result<()> {
                 // Shadow, to avoid moving the variable:
                 let connector_opt = &mut connector_opt;
                 Arc::new_cyclic(move |weak_supervisor| {
-                    let connector = Arc::new(tml_cli_connector::CliConnector::new(
+                    let connector = Arc::new(treadmill_cli_connector::CliConnector::new(
                         config.base.supervisor_id,
                         cli_connector_config,
                         weak_supervisor.clone(),
@@ -690,7 +690,7 @@ async fn main() -> Result<()> {
                 // Shadow, to avoid moving the variable:
                 let connector_opt = &mut connector_opt;
                 Arc::new_cyclic(move |weak_supervisor| {
-                    let connector = Arc::new(tml_ws_connector::WsConnector::new(
+                    let connector = Arc::new(treadmill_ws_connector::WsConnector::new(
                         config.base.supervisor_id,
                         ws_connector_config,
                         weak_supervisor.clone(),

--- a/supervisor/nbd-netboot/Cargo.toml
+++ b/supervisor/nbd-netboot/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "tml-nbd-netboot-supervisor"
+name = "treadmill-nbd-netboot-supervisor"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
 [dependencies]
 treadmill-rs = { path = "../../treadmill-rs" }
-tml-tcp-control-socket-server = { path = "../../control-socket/tcp/server" }
-tml-cli-connector = { path = "../../connector/cli" }
-tml-ws-connector = { path = "../../connector/ws" }
-tml-supervisor-lib = { path = "../lib" }
+treadmill-tcp-control-socket-server = { path = "../../control-socket/tcp/server" }
+treadmill-cli-connector = { path = "../../connector/cli" }
+treadmill-ws-connector = { path = "../../connector/ws" }
+treadmill-supervisor-lib = { path = "../lib" }
 
 tokio = { version = "1.35.1", default-features = false, features = ["rt-multi-thread", "process", "fs"] }
 toml = "0.8.8"

--- a/supervisor/nbd-netboot/src/main.rs
+++ b/supervisor/nbd-netboot/src/main.rs
@@ -21,9 +21,9 @@ use treadmill_rs::control_socket;
 use treadmill_rs::image;
 use treadmill_rs::supervisor::{SupervisorBaseConfig, SupervisorCoordConnector};
 
-use tml_tcp_control_socket_server::TcpControlSocket;
+use treadmill_tcp_control_socket_server::TcpControlSocket;
 
-use tml_supervisor_lib::image_store_client;
+use treadmill_supervisor_lib::image_store_client;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -148,9 +148,9 @@ pub struct NbdNetbootSupervisorConfig {
 
     /// Configurations for individual connector implementations. All are
     /// optional, and not all of them have to be supported:
-    cli_connector: Option<tml_cli_connector::CliConnectorConfig>,
+    cli_connector: Option<treadmill_cli_connector::CliConnectorConfig>,
 
-    ws_connector: Option<tml_ws_connector::WsConnectorConfig>,
+    ws_connector: Option<treadmill_ws_connector::WsConnectorConfig>,
 
     image_store: image_store_client::LocalImageStoreConfig,
 
@@ -2009,7 +2009,7 @@ async fn main() -> Result<()> {
                 // Shadow, to avoid moving the variable:
                 let connector_opt = &mut connector_opt;
                 Arc::new_cyclic(move |weak_supervisor| {
-                    let connector = Arc::new(tml_cli_connector::CliConnector::new(
+                    let connector = Arc::new(treadmill_cli_connector::CliConnector::new(
                         config.base.supervisor_id,
                         cli_connector_config,
                         weak_supervisor.clone(),
@@ -2044,7 +2044,7 @@ async fn main() -> Result<()> {
                 // Shadow, to avoid moving the variable:
                 let connector_opt = &mut connector_opt;
                 Arc::new_cyclic(move |weak_supervisor| {
-                    let connector = Arc::new(tml_ws_connector::WsConnector::new(
+                    let connector = Arc::new(treadmill_ws_connector::WsConnector::new(
                         config.base.supervisor_id,
                         ws_connector_config,
                         weak_supervisor.clone(),

--- a/supervisor/qemu/Cargo.toml
+++ b/supervisor/qemu/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "tml-qemu-supervisor"
+name = "treadmill-qemu-supervisor"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
 [dependencies]
 treadmill-rs = { path = "../../treadmill-rs" }
-tml-tcp-control-socket-server = { path = "../../control-socket/tcp/server" }
-tml-cli-connector = { path = "../../connector/cli" }
-tml-ws-connector = { path = "../../connector/ws" }
-tml-supervisor-lib = { path = "../lib" }
+treadmill-tcp-control-socket-server = { path = "../../control-socket/tcp/server" }
+treadmill-cli-connector = { path = "../../connector/cli" }
+treadmill-ws-connector = { path = "../../connector/ws" }
+treadmill-supervisor-lib = { path = "../lib" }
 
 tokio = { version = "1.35.1", default-features = false, features = ["rt-multi-thread", "process", "fs"] }
 toml = "0.8.8"

--- a/supervisor/qemu/src/main.rs
+++ b/supervisor/qemu/src/main.rs
@@ -20,9 +20,9 @@ use treadmill_rs::control_socket;
 use treadmill_rs::image;
 use treadmill_rs::supervisor::{SupervisorBaseConfig, SupervisorCoordConnector};
 
-use tml_tcp_control_socket_server::TcpControlSocket;
+use treadmill_tcp_control_socket_server::TcpControlSocket;
 
-use tml_supervisor_lib::image_store_client;
+use treadmill_supervisor_lib::image_store_client;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -148,9 +148,9 @@ pub struct QemuSupervisorConfig {
 
     /// Configurations for individual connector implementations. All are
     /// optional, and not all of them have to be supported:
-    cli_connector: Option<tml_cli_connector::CliConnectorConfig>,
+    cli_connector: Option<treadmill_cli_connector::CliConnectorConfig>,
 
-    ws_connector: Option<tml_ws_connector::WsConnectorConfig>,
+    ws_connector: Option<treadmill_ws_connector::WsConnectorConfig>,
 
     image_store: image_store_client::LocalImageStoreConfig,
 
@@ -1823,7 +1823,7 @@ async fn main() -> Result<()> {
                 // Shadow, to avoid moving the variable:
                 let connector_opt = &mut connector_opt;
                 Arc::new_cyclic(move |weak_supervisor| {
-                    let connector = Arc::new(tml_cli_connector::CliConnector::new(
+                    let connector = Arc::new(treadmill_cli_connector::CliConnector::new(
                         config.base.supervisor_id,
                         cli_connector_config,
                         weak_supervisor.clone(),
@@ -1858,7 +1858,7 @@ async fn main() -> Result<()> {
                 // Shadow, to avoid moving the variable:
                 let connector_opt = &mut connector_opt;
                 Arc::new_cyclic(move |weak_supervisor| {
-                    let connector = Arc::new(tml_ws_connector::WsConnector::new(
+                    let connector = Arc::new(treadmill_ws_connector::WsConnector::new(
                         config.base.supervisor_id,
                         ws_connector_config,
                         weak_supervisor.clone(),

--- a/switchboard/Cargo.toml
+++ b/switchboard/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tml-switchboard"
+name = "treadmill-switchboard"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/switchboard/src/bin/swx.rs
+++ b/switchboard/src/bin/swx.rs
@@ -1,7 +1,7 @@
 //! Switchboard runner. Run as a command-line tool.
 
 use clap::{Parser, Subcommand};
-use tml_switchboard::serve::ServeCommand;
+use treadmill_switchboard::serve::ServeCommand;
 
 #[derive(Debug, Parser)]
 #[command(version, about)]
@@ -17,7 +17,7 @@ pub enum Command {
 impl Command {
     async fn run(self) -> miette::Result<()> {
         match self {
-            Command::Serve(serve_cmd) => tml_switchboard::serve::serve(serve_cmd).await,
+            Command::Serve(serve_cmd) => treadmill_switchboard::serve::serve(serve_cmd).await,
         }
     }
 }


### PR DESCRIPTION
We are about to publish an initial version of the Treadmill CLI client to crates.io. While the CLI client crate is named "tml-cli", the base-crate containing API and type definitions, which we have to publish alongside it, is called "treadmill-rs". The "tml-" prefix, while nice and short, is rather ambiguous. We should publish the crates prefixed with "treadmill-", and then produce binaries that are available under the shortened "tml" prefix (such as the CLI crate, which produces a binary named `tml`).