### PR TITLE
Prepare `treadmill-rs` and `treadmill-cli` crates for publishing on crates.io

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "treadmill-cli"
-version.workspace = true
-authors.workspace = true
+version = "0.1.0"
 edition.workspace = true
+
+authors.workspace = true
+categories = ["command-line-utilities", "development-tools::testing"]
+description = "CLI client for the Treadmill distributed hardware testbed"
+homepage = "https://treadmill.ci"
+keywords = ["ci", "testing", "testbed", "hardware", "embedded"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
 
 [[bin]]
 name = "tml"
@@ -19,10 +26,14 @@ uuid = { version = "1.6.1", features = ["serde", "v4"] }
 dirs = "3.0"
 toml = "0.5"
 hex = "0.4"
-treadmill-rs = { path = "../treadmill-rs" }
 log = "0.4.22"
 env_logger = "0.11.5"
 chrono = "0.4.38"
 xdg = "2.5.2"
 ssh2 = "0.9.4"
 base64 = "0.22.1"
+
+[dependencies.treadmill-rs]
+package = "treadmill-rs"
+version = "0.1.0"
+path = "../treadmill-rs"

--- a/treadmill-rs/Cargo.toml
+++ b/treadmill-rs/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "treadmill-rs"
-version.workspace = true
-authors.workspace = true
+version = "0.1.0"
 edition.workspace = true
+
+authors.workspace = true
+categories = ["api-bindings"]
+description = "Common type- and API-definitions for the Treadmill distributed hardware testbed"
+homepage = "https://treadmill.ci"
+keywords = ["ci", "testing", "testbed", "hardware", "embedded"]
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 async-trait = "0.1.75"


### PR DESCRIPTION
Adds the necessary metadata for publishing on crates.io, and adds a "package" dependency of `treadmill-cli` on `treadmill-rs`, next to the "path" dependency we use in this Cargo workspace.