### PR TITLE
puppet: add warning message and append trailing newline to authorized_keys

### DIFF
--- a/puppet/src/main.rs
+++ b/puppet/src/main.rs
@@ -257,7 +257,8 @@ async fn update_authorized_keys(
             )
         })?;
 
-        let authorized_keys = ssh_keys.join("\n");
+        let mut authorized_keys = ssh_keys.join("\n");
+        authorized_keys.push_str("\n");
         tokio::fs::write(authorized_keys_file, authorized_keys.as_bytes())
             .await
             .with_context(|| {

--- a/puppet/src/main.rs
+++ b/puppet/src/main.rs
@@ -257,8 +257,13 @@ async fn update_authorized_keys(
             )
         })?;
 
-        let mut authorized_keys = ssh_keys.join("\n");
-        authorized_keys.push_str("\n");
+        let authorized_keys = format!(
+            "# WARNING: this file is managed by tml-puppet and may be overwritten.\n\
+	     # Please add your own SSH keys to an alternative authorized_keys file\n\
+	     # (such as ~/.ssh/authorized_keys2)\n\
+	     {}\n",
+            ssh_keys.join("\n"),
+        );
         tokio::fs::write(authorized_keys_file, authorized_keys.as_bytes())
             .await
             .with_context(|| {


### PR DESCRIPTION
Whenever the set of SSH keys is updated for a job, the puppet may overwrite the authorized_keys file. We want to make clear that any user-added keys may be overwritten at any time.

Adding a trailing newline helps to avoid accidentally invalidating the last SSH key added by appending further keys to the file (i.e., `cat addl_keys >> .ssh/authorized_keys`). Without a trailing newline, these would be appended to the last SSH key added by the Treadmill puppet).
