### PR TITLE
switchboard: match jobs with supervisors in enqueue order

### DIFF
--- a/switchboard/Cargo.toml
+++ b/switchboard/Cargo.toml
@@ -39,7 +39,7 @@ subtle = "2.6.1"
 # Used for password verification
 argon2 = { version = "0.6.0-pre.0", features = [] }
 # CSPRNG
-rand = { version = "0.9.0-alpha.1", features = ["getrandom"] }
+rand = { version = "0.9.0-alpha.1", features = ["getrandom", "std", "std_rng"] }
 
 # Logging facilities
 tracing = { version = "0.1.40" }

--- a/switchboard/src/service.rs
+++ b/switchboard/src/service.rs
@@ -144,7 +144,12 @@ impl Service {
 
                     {
                         let state = self.state.lock().await;
-                        let idle_set = state.herd.currently_idle();
+                        let mut idle_set = state.herd.currently_idle();
+
+			// Randomize the set of idle supervisors to better
+			// balance the load and wear of the installed boards:
+			rand::seq::SliceRandom::shuffle(&mut idle_set[..], &mut rand::thread_rng());
+
                         let mut queued_jobs = state.kanban.get_queued_jobs();
                         for supervisor_id in idle_set {
                             let mut matched_to = None;


### PR DESCRIPTION
By sorting the jobs returned by the Kanban service, the supervisor match daemon should start earlier jobs first. This ensures fairness during scheduling, and helps to avoid jobs racing against the queue timeout when there's a constant influx of new jobs being enqueued.
