### PR TITLE
GitHub Actions: force-reinstall sqlx-cli, even if cached

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up database
         run: |
           pushd ./switchboard
-          cargo binstall sqlx-cli
+          cargo binstall --force sqlx-cli
           sqlx migrate run
           psql -h localhost -U $POSTGRES_USER -d $POSTGRES_DB -f FIXTURES.sql
           popd

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up database
         run: |
           pushd ./switchboard
-          cargo binstall sqlx-cli
+          cargo binstall --force sqlx-cli
           sqlx migrate run
           psql -h localhost -U $POSTGRES_USER -d $POSTGRES_DB -f FIXTURES.sql
           popd


### PR DESCRIPTION
This should hopefully get rid of some CI errors, which presumably are because we're caching a binstall'ed version that uses a different dynamic loader path?
