### PR TITLE
Rename finished job directories to mark them as old in NbdNetbootSupervisor

### DIFF
--- a/supervisor/nbd-netboot/src/main.rs
+++ b/supervisor/nbd-netboot/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail, Context, Result};
 use async_recursion::async_recursion;
@@ -1620,6 +1621,26 @@ impl NbdNetbootSupervisor {
         self.connector
             .update_job_state(job_id, RunningJobState::Terminated, Some(terminate_message))
             .await;
+
+        // -----------------------------------------------------------
+        // RENAME THE JOB DIRECTORY TO MARK IT OLD
+        //
+        // Example: turn /var/lib/treadmill/.../jobs/<uuid>
+        // into    /var/lib/treadmill/.../jobs/<uuid>-old-1678458722 <- now_secs
+        // -----------------------------------------------------------
+        let now_secs = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(dur) => dur.as_secs(),
+            Err(_) => 0,
+        };
+        if let Some(job_dir_name) = job_workdir.file_name() {
+            if let Some(parent_dir) = job_workdir.parent() {
+                let new_dir_name = format!("{}-old-{}", job_dir_name.to_string_lossy(), now_secs);
+                let old_dir_path = parent_dir.join(new_dir_name);
+                if let Err(e) = tokio::fs::rename(&job_workdir, &old_dir_path).await {
+                    tracing::warn!("Failed to rename old job dir: {:?}", e);
+                }
+            }
+        }
 
         // Finally, remove the job from the jobs HashMap. Eventually, all other
         // `Arc` references (including the one we hold) will get dropped.


### PR DESCRIPTION
This PR updates the NbdNetbootSupervisor so that, whenever a job finishes (either by shutdown or error), its job directory is renamed from `<uuid>` to `<uuid>-old-<timestamp>`. This change happens in the `finish_running_job_shutdown` function. Renaming the directory to include `-old-` and a Unix-epoch timestamp lets external scripts or systemd services easily identify which job directories are inactive and safe to remove.

Key Changes:
- In `finish_running_job_shutdown`, after stopping the QEMU process and removing the job from the internal map, we perform a `tokio::fs::rename` on the `job_workdir` from `<uuid>` to `<uuid>-old-<timestamp>`.
- Warn if the rename fails, but continue the shutdown process so it doesn’t affect job termination flows.
- Ensures that external garbage-collection scripts can detect old job directories by the `-old-` pattern.

This approach preserves old directories for debugging or partial state re-use, while making it straightforward to clean them up later.


Note this PR is linked with [PR#6 in treadmill-tb/deployments](https://github.com/treadmill-tb/deployments/pull/6)