### PR TITLE
Gracefully Shutdown Supervisors on SIGHUP for Config/Version Reload

### DIFF
--- a/connector/cli/src/lib.rs
+++ b/connector/cli/src/lib.rs
@@ -412,7 +412,7 @@ impl<S: connector::Supervisor> CliConnector<S> {
 
 #[async_trait]
 impl<S: connector::Supervisor> connector::SupervisorConnector for CliConnector<S> {
-    async fn run(&self) {
+    async fn run(&self) -> Result<(), ()> {
         // Acquire a "strong" Arc<> reference to the supervisor. Not holding
         // onto a strong reference beyond invocations of "run" will ensure that
         // the contained supervisor can be deallocated properly.
@@ -468,7 +468,7 @@ impl<S: connector::Supervisor> connector::SupervisorConnector for CliConnector<S
                     if let Some(matched) = parsed.exact_match {
                         if matched.execute(&mut cli_state, &supervisor).await {
                             // Asked to quit:
-                            return;
+                            return Ok(());
                         }
                     } else {
                         error!("Internal error: parser did not produce a match for the entered command: {:#?}", parsed);
@@ -476,7 +476,7 @@ impl<S: connector::Supervisor> connector::SupervisorConnector for CliConnector<S
                 }
                 Err(inquire::error::InquireError::OperationCanceled) => {
                     // Asked to quit:
-                    return;
+                    return Ok(());
                 }
                 Err(inquire::error::InquireError::OperationInterrupted) => {
                     // Nop, just print a new command line:

--- a/treadmill-rs/src/connector.rs
+++ b/treadmill-rs/src/connector.rs
@@ -100,9 +100,12 @@ pub trait SupervisorConnector: std::fmt::Debug + Send + Sync + 'static {
     /// Start the connector's main loop.
     ///
     /// Supervisors are expected to execute this method after performing their
-    /// startup initialization. A connector will return from this method when it
-    /// intends the supervisor to shut down.
-    async fn run(&self);
+    /// startup initialization. A connector will return with `Ok(())` when it
+    /// intends the supervisor to shut down, and with `Err(())` in case an error
+    /// occurred communicating with the switchboard. In the latter case,
+    /// supervisors may or may not try to reconnect by calling `run()` in the
+    /// loop.
+    async fn run(&self) -> Result<(), ()>;
 
     async fn update_event(&self, supervisor_event: SupervisorEvent);
 


### PR DESCRIPTION
- Adds a shutdown-requested flag to let the connector exit gracefully instead of killing in-progress jobs.  
- On SIGHUP, we set this flag, and the connector returns from `run()` once idle.  
- The main loop then exits, allowing systemd to restart the supervisor with new config/binaries without interrupting active jobs.






