### PR TITLE
puppet: expose host-id as part of job info files

### DIFF
--- a/puppet/src/control_socket_client.rs
+++ b/puppet/src/control_socket_client.rs
@@ -1,14 +1,13 @@
 use std::collections::HashMap;
 
 use anyhow::{bail, Context, Result};
-use uuid::Uuid;
 
 // TCP control socket transport implementation:
 #[cfg(feature = "transport_tcp")]
 pub use treadmill_tcp_control_socket_client as tcp;
 
 use treadmill_rs::api::supervisor_puppet::{
-    NetworkConfig, ParameterValue, PuppetEvent, PuppetReq, SupervisorEvent, SupervisorResp,
+    JobInfo, NetworkConfig, ParameterValue, PuppetEvent, PuppetReq, SupervisorEvent, SupervisorResp,
 };
 
 pub enum ControlSocketClient {
@@ -62,16 +61,19 @@ impl ControlSocketClient {
         }
     }
 
-    pub async fn get_job_id(&self) -> Result<Uuid> {
+    pub async fn get_job_info(&self) -> Result<JobInfo> {
         let resp = self
-            .request(PuppetReq::JobId)
+            .request(PuppetReq::JobInfo)
             .await
-            .context("Sending job ID request to supervisor")?;
+            .context("Sending job info request to supervisor")?;
 
         match resp {
-            SupervisorResp::JobId { job_id } => Ok(job_id),
+            SupervisorResp::JobInfo(job_info) => Ok(job_info),
             _ => {
-                bail!("Invalid supervisor response to job ID request: {:?}", resp);
+                bail!(
+                    "Invalid supervisor response to job info request: {:?}",
+                    resp
+                );
             }
         }
     }

--- a/supervisor/nbd-netboot/src/main.rs
+++ b/supervisor/nbd-netboot/src/main.rs
@@ -1156,6 +1156,7 @@ impl NbdNetbootSupervisor {
 
         // Start a TCP control socket on the specified listen addr:
         let control_socket = TcpControlSocket::new(
+            this.config.base.supervisor_id,
             start_job_req.job_id,
             this.config.nbd_netboot.tcp_control_socket_listen_addr,
             this.clone(),
@@ -1759,7 +1760,7 @@ impl connector::Supervisor for NbdNetbootSupervisor {
 #[async_trait]
 impl control_socket::Supervisor for NbdNetbootSupervisor {
     #[instrument(skip(self))]
-    async fn ssh_keys(&self, tgt_job_id: Uuid) -> Option<Vec<String>> {
+    async fn ssh_keys(&self, _host_id: Uuid, tgt_job_id: Uuid) -> Option<Vec<String>> {
         match self.jobs.lock().await.get(&tgt_job_id) {
             Some(job_state) => match &*job_state.lock().await {
                 NbdNetbootSupervisorJobState::Running(NbdNetbootSupervisorJobRunningState {
@@ -1795,6 +1796,7 @@ impl control_socket::Supervisor for NbdNetbootSupervisor {
     #[instrument(skip(self))]
     async fn network_config(
         &self,
+        _host_id: Uuid,
         tgt_job_id: Uuid,
     ) -> Option<treadmill_rs::api::supervisor_puppet::NetworkConfig> {
         match self.jobs.lock().await.get(&tgt_job_id) {
@@ -1839,6 +1841,7 @@ impl control_socket::Supervisor for NbdNetbootSupervisor {
     #[instrument(skip(self))]
     async fn parameters(
         &self,
+        _host_id: Uuid,
         tgt_job_id: Uuid,
     ) -> Option<HashMap<String, treadmill_rs::api::supervisor_puppet::ParameterValue>> {
         match self.jobs.lock().await.get(&tgt_job_id) {
@@ -1875,7 +1878,7 @@ impl control_socket::Supervisor for NbdNetbootSupervisor {
     }
 
     #[instrument(skip(self))]
-    async fn puppet_ready(&self, _puppet_event_id: u64, job_id: Uuid) {
+    async fn puppet_ready(&self, _puppet_event_id: u64, _host_id: Uuid, job_id: Uuid) {
         event!(Level::INFO, "Received puppet ready event");
 
         match self.jobs.lock().await.get(&job_id) {
@@ -1914,6 +1917,7 @@ impl control_socket::Supervisor for NbdNetbootSupervisor {
         &self,
         _puppet_event_id: u64,
         _supervisor_event_id: Option<u64>,
+        _host_id: Uuid,
         _job_id: Uuid,
     ) {
         event!(Level::INFO, "Received puppet shutdown event");
@@ -1937,6 +1941,7 @@ impl control_socket::Supervisor for NbdNetbootSupervisor {
         &self,
         _puppet_event_id: u64,
         _supervisor_event_id: Option<u64>,
+        _host_id: Uuid,
         _job_id: Uuid,
     ) {
         event!(Level::INFO, "Received puppet reboot event");
@@ -1960,6 +1965,7 @@ impl control_socket::Supervisor for NbdNetbootSupervisor {
         &self,
         _puppet_event_id: u64,
         _supervisor_event_id: Option<u64>,
+        _host_id: Uuid,
         job_id: Uuid,
     ) {
         event!(

--- a/supervisor/qemu/src/main.rs
+++ b/supervisor/qemu/src/main.rs
@@ -1082,6 +1082,7 @@ impl QemuSupervisor {
 
         // Start a TCP control socket on the specified listen addr:
         let control_socket = TcpControlSocket::new(
+            this.config.base.supervisor_id,
             start_job_req.job_id,
             this.config.qemu.tcp_control_socket_listen_addr,
             this.clone(),
@@ -1573,7 +1574,7 @@ impl connector::Supervisor for QemuSupervisor {
 #[async_trait]
 impl control_socket::Supervisor for QemuSupervisor {
     #[instrument(skip(self))]
-    async fn ssh_keys(&self, tgt_job_id: Uuid) -> Option<Vec<String>> {
+    async fn ssh_keys(&self, _host_id: Uuid, tgt_job_id: Uuid) -> Option<Vec<String>> {
         match self.jobs.lock().await.get(&tgt_job_id) {
             Some(job_state) => match &*job_state.lock().await {
                 QemuSupervisorJobState::Running(QemuSupervisorJobRunningState {
@@ -1609,6 +1610,7 @@ impl control_socket::Supervisor for QemuSupervisor {
     #[instrument(skip(self))]
     async fn network_config(
         &self,
+        _host_id: Uuid,
         tgt_job_id: Uuid,
     ) -> Option<treadmill_rs::api::supervisor_puppet::NetworkConfig> {
         match self.jobs.lock().await.get(&tgt_job_id) {
@@ -1653,6 +1655,7 @@ impl control_socket::Supervisor for QemuSupervisor {
     #[instrument(skip(self))]
     async fn parameters(
         &self,
+        _host_id: Uuid,
         tgt_job_id: Uuid,
     ) -> Option<HashMap<String, treadmill_rs::api::supervisor_puppet::ParameterValue>> {
         match self.jobs.lock().await.get(&tgt_job_id) {
@@ -1689,7 +1692,7 @@ impl control_socket::Supervisor for QemuSupervisor {
     }
 
     #[instrument(skip(self))]
-    async fn puppet_ready(&self, _puppet_event_id: u64, job_id: Uuid) {
+    async fn puppet_ready(&self, _puppet_event_id: u64, _host_id: Uuid, job_id: Uuid) {
         event!(Level::INFO, "Received puppet ready event");
 
         match self.jobs.lock().await.get(&job_id) {
@@ -1728,6 +1731,7 @@ impl control_socket::Supervisor for QemuSupervisor {
         &self,
         _puppet_event_id: u64,
         _supervisor_event_id: Option<u64>,
+        _host_id: Uuid,
         _job_id: Uuid,
     ) {
         event!(Level::INFO, "Received puppet shutdown event");
@@ -1751,6 +1755,7 @@ impl control_socket::Supervisor for QemuSupervisor {
         &self,
         _puppet_event_id: u64,
         _supervisor_event_id: Option<u64>,
+        _host_id: Uuid,
         _job_id: Uuid,
     ) {
         event!(Level::INFO, "Received puppet reboot event");
@@ -1774,6 +1779,7 @@ impl control_socket::Supervisor for QemuSupervisor {
         &self,
         _puppet_event_id: u64,
         _supervisor_event_id: Option<u64>,
+        _host_id: Uuid,
         job_id: Uuid,
     ) {
         event!(

--- a/treadmill-rs/src/api/supervisor_puppet.rs
+++ b/treadmill-rs/src/api/supervisor_puppet.rs
@@ -14,7 +14,7 @@ pub use super::switchboard_supervisor::ParameterValue;
 #[non_exhaustive]
 pub enum PuppetReq {
     Ping,
-    JobId,
+    JobInfo,
     SSHKeys,
     NetworkConfig,
     Parameters,
@@ -191,14 +191,19 @@ pub struct NetworkConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+pub struct JobInfo {
+    pub job_id: Uuid,
+    pub host_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 #[serde(tag = "type")]
 #[non_exhaustive]
 pub enum SupervisorResp {
     // Request reponses:
     PingResp,
-    JobId {
-        job_id: Uuid,
-    },
+    JobInfo(JobInfo),
     SSHKeysResp {
         ssh_keys: Vec<String>,
     },


### PR DESCRIPTION
This changes the `job_id_path` parameter to a `job_info_dir` parameter, such that general job metadata may be written to this directory without further command line parameter changes. As of now, this path will have `job-id` and `host-id` propagated, but further files / metadata may be added in the future (like a job label).

This PR raises the question: are the "host IDs" and "supervisor IDs" really synonymous? Right now, we treat them as such, but at the same time supervisors are written to potentially spawn multiple different jobs simultaneously, on multiple hosts (i.e., there may not always be a 1-to-1 correlation between supervisors and hosts).

It seems fine to assume that they are, and continue with the assumption that---for the time being---there is always a 1-to-1 mapping between supervisor and host. We may want to introduce special support into the switchboard if this assumption is ever violated (such as when spawning a potentially unbounded number of VMs on demand), and create new host IDs on the fly for these resources.

