### PR TITLE
Release treamill-cli v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "treadmill-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treadmill-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 
 authors.workspace = true


### PR DESCRIPTION
The previous release had an incorrect version string embedded in the treadmill-cli binary. This release fixes it and uses the version string based on the `Cargo.toml` manifest instead.
