### PR TITLE
switchboard: replace migra with atlas for SQL schema migrations

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -10,7 +10,6 @@
     let
       cmn = import ./lib.nix { inherit inputs system pkgs; };
       inherit (pkgs) lib;
-      inherit (pkgs.stdenv) isLinux;
 
       switchboardMigrationsSrc = lib.fileset.toSource {
         root = ../switchboard;
@@ -51,12 +50,9 @@
           echo "TODO: end-to-end integration tests"
           mkdir -p $out
         '';
-      }
-      # Verify that applying switchboard/migrations/ in order reproduces
-      # switchboard/SCHEMA.sql exactly (the same check as `./migrate.sh -v`).
-      # Linux-only because it uses the same unix-socket Postgres setup as the
-      # .#database devshell.
-      // lib.optionalAttrs isLinux {
+
+        # Verify that applying switchboard/migrations/ in order reproduces
+        # switchboard/SCHEMA.sql exactly (the same check as `./migrate.sh -v`).
         switchboard-migrations-consistency =
           pkgs.runCommand "switchboard-migrations-consistency"
             {

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -9,6 +9,17 @@
     }:
     let
       cmn = import ./lib.nix { inherit inputs system pkgs; };
+      inherit (pkgs) lib;
+      inherit (pkgs.stdenv) isLinux;
+
+      switchboardMigrationsSrc = lib.fileset.toSource {
+        root = ../switchboard;
+        fileset = lib.fileset.unions [
+          ../switchboard/SCHEMA.sql
+          ../switchboard/migrate.sh
+          ../switchboard/migrations
+        ];
+      };
     in
     {
       checks = {
@@ -40,6 +51,42 @@
           echo "TODO: end-to-end integration tests"
           mkdir -p $out
         '';
+      }
+      # Verify that applying switchboard/migrations/ in order reproduces
+      # switchboard/SCHEMA.sql exactly (the same check as `./migrate.sh -v`).
+      # Linux-only because it uses the same unix-socket Postgres setup as the
+      # .#database devshell.
+      // lib.optionalAttrs isLinux {
+        switchboard-migrations-consistency =
+          pkgs.runCommand "switchboard-migrations-consistency"
+            {
+              nativeBuildInputs = with pkgs; [
+                postgresql
+                atlas
+                bash
+              ];
+            }
+            ''
+              set -euo pipefail
+
+              cp -r ${switchboardMigrationsSrc} switchboard
+              chmod -R u+w switchboard
+              cd switchboard
+
+              PG_BASE_DIR="$(mktemp -d)"
+              initdb -D "$PG_BASE_DIR" >/dev/null
+              pg_ctl -D "$PG_BASE_DIR" -l "$PG_BASE_DIR/log" \
+                -o "-h ''' --unix_socket_directories='$PG_BASE_DIR'" start
+
+              trap 'pg_ctl -D "$PG_BASE_DIR" stop >/dev/null 2>&1 || true' EXIT
+
+              export PGHOST="$PG_BASE_DIR"
+              export PGUSER="$(id -un)"
+
+              bash ./migrate.sh -v
+
+              touch $out
+            '';
       }
       # Promote each package output to a check so `nix flake check`
       # verifies they all build.

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -8,8 +8,6 @@
     }:
     let
       cmn = import ./lib.nix { inherit inputs system pkgs; };
-      inherit (pkgs) lib;
-      inherit (pkgs.stdenv) isLinux;
 
       defaultShell = cmn.craneLib.devShell {
         packages = with pkgs; [
@@ -72,7 +70,7 @@
     {
       devShells = {
         default = defaultShell;
-      }
-      // lib.optionalAttrs isLinux { database = databaseShell; };
+        database = databaseShell;
+      };
     };
 }

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -31,86 +31,12 @@
         '';
       };
 
-      # Ephemeral PostgreSQL devshell for switchboard / sqlx work:
-      pythonPackages = pkgs.python3Packages.override {
-        overrides = self: _super: {
-          flask = self.buildPythonPackage rec {
-            pname = "Flask";
-            version = "2.2.5";
-            src = self.fetchPypi {
-              inherit pname version;
-              sha256 = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
-            };
-            pyproject = true;
-            build-system = [ pythonPackages.setuptools ];
-            propagatedBuildInputs = with self; [
-              itsdangerous
-              click
-              jinja2
-              werkzeug
-            ];
-          };
-
-          sqlbag = self.buildPythonPackage rec {
-            pname = "sqlbag";
-            version = "0.1.1617247075";
-            src = self.fetchPypi {
-              inherit pname version;
-              sha256 = "sha256-udeGLDsgMDVteWyocpB5Yv1UcEBml4166JOD9RIzZu0=";
-            };
-            pyproject = true;
-            build-system = [ pythonPackages.setuptools ];
-            propagatedBuildInputs = with self; [
-              flask
-              sqlalchemy
-              psycopg2
-              six
-            ];
-            doCheck = false;
-          };
-        };
-      };
-
-      schemainspect = pythonPackages.buildPythonPackage rec {
-        pname = "schemainspect";
-        version = "3.1.1663587362";
-        src = pythonPackages.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-opWtVvehnAnl4e+fFtrb9jkuJhlstfBbWv5hPJnOdGg=";
-        };
-        pyproject = true;
-        build-system = [ pythonPackages.setuptools ];
-        propagatedBuildInputs = with pythonPackages; [
-          sqlbag
-          setuptools
-        ];
-      };
-
-      migra = pythonPackages.buildPythonPackage rec {
-        pname = "migra";
-        version = "3.0.1663481299";
-        src = pythonPackages.fetchPypi {
-          inherit pname version;
-          sha256 = "sha256-DPDBJdVTAI2f9UAmY6UXA8zEdLtltaT0cnkG2/WOIX8=";
-        };
-        pyproject = true;
-        build-system = [ pythonPackages.setuptools ];
-        propagatedBuildInputs = with pythonPackages; [
-          schemainspect
-          sqlbag
-          psycopg2
-          click
-        ];
-      };
-
       databaseShell = pkgs.mkShell {
         name = "treadmill-db-migrate-shell";
 
         packages = with pkgs; [
           postgresql
-          migra
-          schemainspect
-          pythonPackages.psycopg2
+          atlas
           sql-formatter
           sqlx-cli
         ];

--- a/switchboard/README.md
+++ b/switchboard/README.md
@@ -1,0 +1,35 @@
+# `tml-switchboard`
+
+## Switchboard Database Migrations
+
+The Switchboard's PostgreSQL schema is maintained in two sets of files that must
+agree at all times:
+
+- **`switchboard/SCHEMA.sql`** — the hand-written, commented source of truth
+  describing the desired schema. When working on the switchboard, edits to the
+  schema should primarily go into this file.
+
+- **`switchboard/migrations/`** — an ordered sequence of timestamped migration
+  files. These are embedded into the Switchboard binary by `build.rs` and
+  applied automatically at startup via `sqlx::migrate!()`.
+
+[Atlas](https://atlasgo.io) is used to keep the two in sync: it generates new
+migrations by diffing the cumulative state of `migrations/` against
+`SCHEMA.sql`, and it verifies in CI that replaying `migrations/` reproduces
+`SCHEMA.sql` exactly. The `migrations/atlas.sum` file is Atlas's integrity
+manifest and is committed alongside the migration files; sqlx ignores it at
+runtime.
+
+### Working on migrations
+
+Enter the database devshell using `nix develop '.#database'`, which provisions
+an ephemeral PostgreSQL instance and exports `PGHOST`/`PGUSER` for the
+`migrate.sh` helper script.
+
+Then, from the `switchboard/` directory:
+
+| Command                  | What it does                                                                                                                              |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `./migrate.sh -c <name>` | Generate `migrations/<timestamp>_<name>.sql` from the diff between the current `migrations/` state and `SCHEMA.sql`. Updates `atlas.sum`. |
+| `./migrate.sh -v`        | Verify that applying all migrations in order reproduces `SCHEMA.sql`. Exits non-zero on drift; also run as a `nix flake check`.           |
+| `./migrate.sh -r`        | Re-hash `migrations/atlas.sum` after manually editing a migration file (e.g., to add a backfill step that Atlas could not infer).         |

--- a/switchboard/migrate.sh
+++ b/switchboard/migrate.sh
@@ -1,130 +1,85 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash database-shell.nix
+#! /usr/bin/env bash
+#
+# Manage switchboard SQL migrations using Atlas.
+#
+# SCHEMA.sql is the hand-written source of truth. The migrations/ directory
+# holds the ordered, derived migration files (also applied at runtime by
+# sqlx::migrate!() in build.rs). Atlas keeps the two in sync:
+#
+#   ./migrate.sh -c <name>   author a new migration from the current diff
+#                            between cumulative migrations/ and SCHEMA.sql
+#   ./migrate.sh -v          verify migrations/ reproduces SCHEMA.sql
+#   ./migrate.sh -r          re-hash migrations/atlas.sum after a manual edit
+#
+# Run inside the .#database devshell, which provides Postgres + Atlas and an
+# ephemeral PGHOST/PGUSER.
 
-# The above expression ensures that we're running in a Nix shell with an
-# emphemeral database instance.
+set -euo pipefail
 
-set -e
+cd "$(dirname "$(readlink -f "$0")")"
 
-function usage() {
-    echo "Usage: $(basename $0) [-c <migration name>] [-v]" >&2
+: "${PGHOST:?Run inside the .#database devshell}"
+: "${PGUSER:?Run inside the .#database devshell}"
+
+DEV_DB="tml_switchboard_atlas_dev"
+DEV_URL="postgres://${PGUSER}@/${DEV_DB}?host=${PGHOST}&sslmode=disable"
+DIR="file://migrations"
+SCHEMA_FILE="file://SCHEMA.sql"
+SCOPE=(--schema tml_switchboard)
+
+# Atlas reads schema state by replaying SQL into a dev database. Postgres
+# auto-creates a `public` schema in any new DB, which atlas would otherwise
+# diff against SCHEMA.sql and want to drop. Start each run from a DB with
+# only the schemas SCHEMA.sql defines.
+reset_dev_db() {
+    dropdb -h "$PGHOST" -U "$PGUSER" --if-exists "$DEV_DB" >/dev/null
+    createdb -h "$PGHOST" -U "$PGUSER" "$DEV_DB"
+    psql -h "$PGHOST" -U "$PGUSER" -d "$DEV_DB" -q \
+        -c 'DROP SCHEMA IF EXISTS public CASCADE' >/dev/null
 }
+trap 'dropdb -h "$PGHOST" -U "$PGUSER" --if-exists "$DEV_DB" >/dev/null 2>&1 || true' EXIT
 
-function create_migration_dbs() {
-    # Create a set of temporary databases for migra to be able to diff:
-    SOURCE_DB="tml_switchboard_migra_source_db"
-    createdb -h $PGHOST -U $PGUSER $SOURCE_DB
-    SOURCE_DATABASE_URL_URIENCODE="postgresql://${PGUSER}@${PGHOST_URIENCODE}/${SOURCE_DB}"
-    SOURCE_DATABASE_URL_HOSTPARAM="postgresql://${PGUSER}@/${SOURCE_DB}?host=${PGHOST}"
-
-    TARGET_DB="tml_switchboard_migra_target_db"
-    createdb -h $PGHOST -U $PGUSER $TARGET_DB
-    TARGET_DATABASE_URL_URIENCODE="postgresql://${PGUSER}@${PGHOST_URIENCODE}/${TARGET_DB}"
-    TARGET_DATABASE_URL_HOSTPARAM="postgresql://${PGUSER}@/${TARGET_DB}?host=${PGHOST}"
-}
-
-function op_create_migration() {
-    create_migration_dbs
-
-    # Apply all existing migrations to the source database:
-    echo "Applying existing migrations to the source database." >&2
-    DATABASE_URL="$SOURCE_DATABASE_URL_URIENCODE" sqlx migrate run
-
-    # Apply the target schema to the destination database:
-    echo "Loading new schema into the target database." >&2
-    psql -v ON_ERROR_STOP=1 -U $PGUSER -h $PGHOST -d $TARGET_DB -f ./SCHEMA.sql
-
-    # Create a new SQLX migration file:
-    echo "Creating new SQLx migration file..."
-    MIGRATION_SQL="$(sqlx migrate add -t -- "$1" | cut -d' ' -f 2-)"
-
-    # Use Migra to generate migration script
-    echo "Generating migration script using Migra..." >&2
-    migra \
-        --unsafe \
-        --schema tml_switchboard \
-        "$SOURCE_DATABASE_URL_HOSTPARAM" \
-        "$TARGET_DATABASE_URL_HOSTPARAM" \
-        > "$MIGRATION_SQL" || true
-    echo "Script generated: $MIGRATION_SQL"
-}
-
-function op_validate() {
-    create_migration_dbs
-
-    # Apply all existing migrations to the source database:
-    echo "Applying existing migrations to the source database." >&2
-    DATABASE_URL="$SOURCE_DATABASE_URL_URIENCODE" sqlx migrate run
-
-    # Apply the target schema to the destination database:
-    echo "Loading new schema into the target database." >&2
-    psql -v ON_ERROR_STOP=1 -U $PGUSER -h $PGHOST -d $TARGET_DB -f ./SCHEMA.sql
-
-    # Ensure that the diff between the two databases is empty:
-    TEMP_SQL_DIFF="$(mktemp -t tmlswbdbdiff-XXXXX.sql)"
-    echo "Generating diff using Migra (at $TEMP_SQL_DIFF)..." >&2
-    migra \
-        --unsafe \
-        --schema tml_switchboard \
-        "$SOURCE_DATABASE_URL_HOSTPARAM" \
-        "$TARGET_DATABASE_URL_HOSTPARAM" \
-        > "$TEMP_SQL_DIFF" || true
-
-    if [ -s "$TEMP_SQL_DIFF" ]; then
-	echo "Database schema diff at $TEMP_SQL_DIFF is non-empty! Validation failed. Diff:" >&2
-	echo "" >&2
-	cat "$TEMP_SQL_DIFF"
-	exit 1
-    else
-	echo "Database schema diff is empty, validation succeeded." >&2
-	rm "$TEMP_SQL_DIFF"
-	exit 0
-    fi
+usage() {
+    sed -n '3,16p' "$0" >&2
 }
 
 OPERATION=""
+NAME=""
 
-while getopts ':c:vh' opt; do
+while getopts ':c:vrh' opt; do
     case "$opt" in
-	c)
-	    test "$OPERATION" == "" \
-		|| (echo "Create migration (-c) conflicts with operation $OPERATION" >&2 || exit 1)
-	    OPERATION="create-migration"
-	    MIGRATION_LABEL="$OPTARG"
-	    ;;
-
-	v)
-	    test "$OPERATION" == "" \
-		|| (echo "Validate (-v) conflicts with operation $OPERATION" >&2 || exit 1)
-	    OPERATION="validate"
-	    ;;
-
-	h)
-	    usage
-	    exit 0
-	    ;;
-
-	:)
-	    echo "option requires an argument." >&2
-	    usage
-	    exit 1
-	    ;;
-
-	?)
-	    echo "Invalid command option." >&2
-	    usage
-	    exit 1
-	    ;;
+        c) OPERATION="create"; NAME="$OPTARG" ;;
+        v) OPERATION="validate" ;;
+        r) OPERATION="rehash" ;;
+        h) usage; exit 0 ;;
+        :) echo "Option -$OPTARG requires an argument." >&2; usage; exit 1 ;;
+        \?) echo "Unknown option: -$OPTARG" >&2; usage; exit 1 ;;
     esac
 done
-shift "$(($OPTIND -1))"
 
-if [ "$OPERATION" == "create-migration" ]; then
-    op_create_migration "$MIGRATION_LABEL"
-elif [ "$OPERATION" == "validate" ]; then
-    op_validate
-else
-    echo "Missing operation, pass either -c or -v." >&2
-    usage
-    exit 1
-fi
+case "$OPERATION" in
+    create)
+        reset_dev_db
+        atlas migrate diff "$NAME" \
+            --dir "$DIR" --to "$SCHEMA_FILE" --dev-url "$DEV_URL" "${SCOPE[@]}"
+        ;;
+    validate)
+        atlas migrate validate --dir "$DIR"
+        reset_dev_db
+        diff_output=$(atlas schema diff \
+            --from "$DIR" --to "$SCHEMA_FILE" --dev-url "$DEV_URL" "${SCOPE[@]}")
+        if [ "$diff_output" != "Schemas are synced, no changes to be made." ]; then
+            echo "Schema drift between migrations/ and SCHEMA.sql:" >&2
+            echo "$diff_output" >&2
+            exit 1
+        fi
+        echo "Migrations are in sync with SCHEMA.sql." >&2
+        ;;
+    rehash)
+        atlas migrate hash --dir "$DIR"
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/switchboard/migrations/atlas.sum
+++ b/switchboard/migrations/atlas.sum
@@ -1,0 +1,4 @@
+h1:zGbdNinZuckap+ZOILnwItoAF0dIWZ9W+A1LXw/F09o=
+00000000000001_base.sql h1:frftxPkUDOJS4m+L8YsWkOiSX2MnDyarR4XiQxbcFk4=
+20250113224121_add_host_job_ssh_endpoints.sql h1:Esa7SvUXholzqUG3gPElKGGXmmEVxZCfpRtN+RCgqUE=
+20250210235044_ssh_endpoint_host_port_struct.sql h1:ASBF7HeYHo27w72gRBmE8BTEUD1ei3PfoZgss9ph3KE=


### PR DESCRIPTION
The migra/schemainspect/sqlbag stack was removed from nixpkgs as unmaintained, leaving the database devshell broken on a fresh build (poetry-core/setuptools backend mismatch). Atlas covers the same "SCHEMA.sql is the source of truth, migrations/ is derived, the two must agree" workflow as a single static Go binary that lives in nixpkgs.

- nix/devshells.nix: drop the Python overrides (flask 2.2.5, sqlbag, schemainspect, migra) and pull in pkgs.atlas instead.
- switchboard/migrate.sh: rewrite around `atlas migrate diff` (-c) and `atlas schema diff` (-v); add -r to re-hash atlas.sum after a manual edit.
- switchboard/migrations/atlas.sum: Atlas's integrity manifest, committed alongside the migration files (sqlx ignores it at runtime).
- nix/checks.nix: add switchboard-migrations-consistency, which runs the same -v check inside the build sandbox.
- README.md: document the SCHEMA.sql + migrations/ workflow.

The .#database devshell and the new check stay Linux-only, inherited from the prior Postgres-in-shell setup. Nothing in the atlas / pg pipeline looks intrinsically non-portable, so dropping both isLinux guards is worth a try on a real macOS box.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
