### PR TITLE
.github/workflows/static-checks: trim PR checks to a fast subset

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -41,7 +41,23 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
-      - name: nix flake check
+      # On `pull_request`, only build a curated subset of checks to keep PR
+      # feedback fast. The full `nix flake check` runs in `merge_group` (which
+      # gates merging into main) and on `push` to main, so heavier builds
+      # (musl cross-compile of tml-puppet, swx-image, per-binary package
+      # derivations, etc.) still get exercised before anything lands.
+      - name: nix build (PR fast checks)
+        if: github.event_name == 'pull_request'
+        run: |
+          SYSTEM="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
+          nix build --print-build-logs \
+            ".#checks.${SYSTEM}.clippy" \
+            ".#checks.${SYSTEM}.workspace" \
+            ".#checks.${SYSTEM}.switchboard-migrations-consistency" \
+            ".#checks.${SYSTEM}.treefmt"
+
+      - name: nix flake check (full)
+        if: github.event_name != 'pull_request'
         run: nix flake check --print-build-logs
 
   deploy-switchboard:


### PR DESCRIPTION
`nix flake check` runs again in merge_group (gating main) and once more
on push to main, so PR runs don't need to build the slow musl cross
puppet, swx-image, or the per-binary package derivations. On
pull_request, build only clippy, workspace, migrations-consistency, and
treefmt; full `nix flake check` still runs everywhere else.

The system attribute is resolved from `builtins.currentSystem` so the
same step works unchanged if/when aarch64 or darwin runners are added.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
