### PR TITLE
nix: replace workspace build check with cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           SYSTEM="$(nix eval --impure --raw --expr 'builtins.currentSystem')"
           nix build --print-build-logs \
             ".#checks.${SYSTEM}.clippy" \
-            ".#checks.${SYSTEM}.workspace" \
+            ".#checks.${SYSTEM}.nextest" \
             ".#checks.${SYSTEM}.switchboard-migrations-consistency" \
             ".#checks.${SYSTEM}.treefmt"
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -32,16 +32,28 @@
           }
         );
 
-        # Builds all workspace crates as a single derivation. Catches
-        # workspace-wide regressions that per-binary builds might miss.
-        workspace = cmn.craneLib.cargoBuild (
+        # Run the workspace test suite via cargo-nextest. Scoped to
+        # `--workspace` (NOT `--all-targets`): the per-binary `mkBin`
+        # derivations already build `--bins` against their correctly-scoped
+        # per-group deps layer, and `--all-targets` here would re-build them
+        # against the union-feature `workspaceDeps`, defeating the per-group
+        # split. `--no-tests=pass` keeps this green while the workspace has
+        # no `#[test]` targets yet; remove it once tests exist and you'd
+        # rather a crate accidentally losing all its tests be a CI failure.
+        #
+        # Tests that need external services (e.g. a Postgres for switchboard)
+        # will need wiring here — see `switchboard-migrations-consistency`
+        # below for the ephemeral-pg pattern that works inside the Nix
+        # sandbox.
+        nextest = cmn.craneLib.cargoNextest (
           cmn.cargoCommonArgs
           // {
-            pname = "treadmill-workspace";
+            pname = "treadmill-nextest";
             version = "0.1.0";
             cargoArtifacts = cmn.workspaceDeps;
-            cargoExtraArgs = "--locked --workspace --all-targets";
-            doCheck = false;
+            cargoNextestExtraArgs = "--workspace --no-tests=pass";
+            partitions = 1;
+            partitionType = "count";
           }
         );
 

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -19,6 +19,7 @@
           deadnix
           taplo
           cargo-audit
+          cargo-nextest
           cargo-outdated
         ];
 


### PR DESCRIPTION
The previous `workspace` check did `cargo build --workspace --all-targets`
against the union-feature `workspaceDeps`, which re-compiled every `[[bin]]`
that the per-group `mkBin` derivations also build — defeating the per-group
deps split (e5bd616) for those binaries.

Replace it with a `cargoNextest` check scoped to `--workspace` (no
`--all-targets`), so the bin compilation isn't duplicated and we additionally
get to run any tests that exist. `--no-tests=pass` keeps the check green
while the workspace has no `#[test]` targets yet; drop it once tests land if
you'd prefer "this crate has no tests" to be a CI failure.

Also wire `cargo-nextest` into the default dev shell so `cargo nextest run`
works inside `nix develop`, and update the PR-fast CI list to reference the
renamed `nextest` check.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
