### PR TITLE
nix/apps: give `switchboard-sqlx-prepare` a C compiler

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -47,17 +47,3 @@ Currently, `manage` is the same as ownership: it allows to change ownership
 arbitrary. There should be a more granular permission that allows to change
 attributes of the resource (such as a host's label or tag set), without being
 able to change the ACLs or ownership attribute.
-
-## `switchboard-sqlx-prepare` app lacks a C compiler
-
-The `switchboard-sqlx-prepare` dev app (`nix/apps.nix`) fails: its
-`runtimeInputs` list the Rust toolchain, `postgresql`, `sqlx-cli`, `coreutils`,
-and `pkg-config`, but no C compiler. `cargo sqlx prepare` forces a full
-workspace recompile, which builds the transitive `aws-lc-sys` C dependency;
-its `build.rs` invokes `cc`, doesn't find it, and panics (`ToolNotFound:
-failed to find tool "cc"`). The `.#database` devshell works because it puts
-the stdenv `cc` on `PATH`. Fix: add a C toolchain (e.g. `stdenv.cc`, and
-likely `cmake`) to the app's `runtimeInputs`. Workaround until then: run the
-`sqlx migrate run` + `cargo clean -p treadmill-switchboard` +
-`cargo sqlx prepare --workspace -- --all-targets` steps by hand inside
-`nix develop .#database`.

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -212,6 +212,10 @@
           sqlx-cli
           coreutils
           pkg-config
+          # `cargo sqlx prepare` recompiles the whole workspace, including the
+          # transitive `aws-lc-sys` C sources; its build.rs needs a `cc` on
+          # PATH (the devshells get one implicitly via mkShell's stdenv).
+          stdenv.cc
         ];
         text = ''
           set -euo pipefail


### PR DESCRIPTION
The app failed on any run: `cargo sqlx prepare` forces a full workspace
recompile, which builds the transitive `aws-lc-sys` C sources, and its
build.rs panicked with `ToolNotFound: failed to find tool "cc"`. The
devshells never hit this because `mkShell` puts the stdenv `cc` wrapper on
PATH implicitly; `writeShellApplication` only provides its explicit
`runtimeInputs`. Add `stdenv.cc` there. `cmake` is not needed -- the
`.#database` shell builds `aws-lc-sys` with just `cc`, and so does the app
now (verified: a full `nix run .#switchboard-sqlx-prepare` completes and
reproduces the committed `.sqlx` cache byte-identically).

Drop the corresponding TODOS.md entry.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
