### PR TITLE
Use Postgres NOTIFY to avoid polling-delays

### DIFF
--- a/switchboard/SCHEMA.sql
+++ b/switchboard/SCHEMA.sql
@@ -1391,11 +1391,21 @@ end;
 $$;
 
 
-CREATE TRIGGER jobs_notify
+-- UPDATE triggers are split from INSERT/DELETE so they can carry
+-- `WHEN (OLD.* IS DISTINCT FROM NEW.*)`: an UPDATE that rewrites a row without
+-- changing it emits nothing. This matters because reconciliation re-applies
+-- the current state idempotently — without the guard, a consumer's own no-op
+-- write would wake it again, sustaining a wake/write cycle at the debounce
+-- rate.
+CREATE TRIGGER jobs_notify_write
 AFTER insert
-OR
-UPDATE
 OR delete ON tml_switchboard.jobs FOR each ROW
+EXECUTE function tml_switchboard.notify_change ('job_id', 'dispatched_on_host_id');
+
+
+CREATE TRIGGER jobs_notify_update
+AFTER
+UPDATE ON tml_switchboard.jobs FOR each ROW WHEN (OLD.* IS DISTINCT FROM NEW.*)
 EXECUTE function tml_switchboard.notify_change ('job_id', 'dispatched_on_host_id');
 
 
@@ -1404,12 +1414,16 @@ EXECUTE function tml_switchboard.notify_change ('job_id', 'dispatched_on_host_id
 -- connect still surfaces (a new worker increments `worker_instance_id`); a
 -- clean disconnect only NULLs `last_seen_at` and deliberately stays silent —
 -- no receiver acts on host death, the liveness cutoff covers it.
-CREATE TRIGGER hosts_notify
+CREATE TRIGGER hosts_notify_write
 AFTER insert
-OR
+OR delete ON tml_switchboard.hosts FOR each ROW
+EXECUTE function tml_switchboard.notify_change ('host_id');
+
+
+CREATE TRIGGER hosts_notify_update
+AFTER
 UPDATE OF current_job,
 tags,
 owner_id,
-worker_instance_id
-OR delete ON tml_switchboard.hosts FOR each ROW
+worker_instance_id ON tml_switchboard.hosts FOR each ROW WHEN (OLD.* IS DISTINCT FROM NEW.*)
 EXECUTE function tml_switchboard.notify_change ('host_id');

--- a/switchboard/SCHEMA.sql
+++ b/switchboard/SCHEMA.sql
@@ -1422,8 +1422,8 @@ EXECUTE function tml_switchboard.notify_change ('host_id');
 
 CREATE TRIGGER hosts_notify_update
 AFTER
-UPDATE OF current_job,
-tags,
-owner_id,
-worker_instance_id ON tml_switchboard.hosts FOR each ROW WHEN (OLD.* IS DISTINCT FROM NEW.*)
-EXECUTE function tml_switchboard.notify_change ('host_id');
+UPDATE ON tml_switchboard.hosts FOR each ROW WHEN (
+    -- Exclude `last_seen_at` from check
+    (to_jsonb(OLD) - 'last_seen_at') IS DISTINCT FROM (to_jsonb(NEW) - 'last_seen_at')
+)
+EXECUTE FUNCTION tml_switchboard.notify_change ('host_id');

--- a/switchboard/SCHEMA.sql
+++ b/switchboard/SCHEMA.sql
@@ -1328,3 +1328,88 @@ CREATE TRIGGER audit_events_append_only before
 UPDATE
 OR delete ON tml_switchboard.audit_events FOR each ROW
 EXECUTE function tml_switchboard.deny_audit_event_change ();
+
+
+-- =============================================================================
+-- CHANGE NOTIFICATIONS
+-- =============================================================================
+--
+-- Row-change wake-ups over LISTEN/NOTIFY, on the single channel `tml_events`.
+-- Notifications are edge triggers, not data carriers: a receiver re-reads the
+-- database instead of acting on the payload, so lost or duplicated
+-- notifications are harmless (receivers keep their poll timers as a staleness
+-- fallback). The payload carries only what routing needs:
+--
+--     {"table": <TG_TABLE_NAME>, "keys": {<column>: [<value>, ...], ...}}
+--
+-- The trigger arguments name the routing-key columns; the first must be the
+-- table's primary key (never NULL, so an ordinary row event always has at
+-- least one key). Each key maps to the distinct non-NULL old/new values, so an
+-- UPDATE that moves a row between scopes wakes both. Because payloads are
+-- minimal, Postgres' per-transaction dedup of identical notifications
+-- coalesces repeated changes to the same row.
+--
+-- Bulk-write cap: past a per-table, per-transaction row count (defaulted in
+-- the function body, overridable per session/transaction via the
+-- `tml_switchboard.notify_row_limit` GUC), further rows emit the keyless form
+-- `{"table": ...}` — identical
+-- payloads, deduped to a single delivered notification — which receivers must
+-- treat as "any row of this table may have changed".
+CREATE OR REPLACE FUNCTION tml_switchboard.notify_change () returns trigger language plpgsql AS $$
+declare
+    guc text := 'tml_switchboard.notify_rows_' || TG_TABLE_NAME;
+    n int := coalesce(nullif(current_setting(guc, true), ''), '0')::int + 1;
+    row_limit int := coalesce(
+        nullif(current_setting('tml_switchboard.notify_row_limit', true), ''),
+        '100')::int;
+    old_j jsonb;
+    new_j jsonb;
+    ks jsonb := '{}'::jsonb;
+    col text;
+    vals jsonb;
+begin
+    perform set_config(guc, n::text, true);
+    if n > row_limit then
+        perform pg_notify('tml_events',
+            jsonb_build_object('table', TG_TABLE_NAME)::text);
+        return null;
+    end if;
+    old_j := case when TG_OP <> 'INSERT' then to_jsonb(OLD) end;
+    new_j := case when TG_OP <> 'DELETE' then to_jsonb(NEW) end;
+    foreach col in array TG_ARGV loop
+        select coalesce(jsonb_agg(distinct v), '[]'::jsonb) into vals
+        from unnest(array[old_j -> col, new_j -> col]) as t (v)
+        where v is not null and v <> 'null'::jsonb;
+        if vals <> '[]'::jsonb then
+            ks := ks || jsonb_build_object(col, vals);
+        end if;
+    end loop;
+    perform pg_notify('tml_events',
+        jsonb_build_object('table', TG_TABLE_NAME, 'keys', ks)::text);
+    return null;
+end;
+$$;
+
+
+CREATE TRIGGER jobs_notify
+AFTER insert
+OR
+UPDATE
+OR delete ON tml_switchboard.jobs FOR each ROW
+EXECUTE function tml_switchboard.notify_change ('job_id', 'dispatched_on_host_id');
+
+
+-- Column-filtered so that heartbeat refreshes (`last_seen_at`) never notify:
+-- they arrive per host per ping interval and carry no scheduling edge. Host
+-- connect still surfaces (a new worker increments `worker_instance_id`); a
+-- clean disconnect only NULLs `last_seen_at` and deliberately stays silent —
+-- no receiver acts on host death, the liveness cutoff covers it.
+CREATE TRIGGER hosts_notify
+AFTER insert
+OR
+UPDATE OF current_job,
+tags,
+owner_id,
+worker_instance_id
+OR delete ON tml_switchboard.hosts FOR each ROW
+EXECUTE function tml_switchboard.notify_change ('host_id');

--- a/switchboard/migrations/20260712034848_pg_notify_events.sql
+++ b/switchboard/migrations/20260712034848_pg_notify_events.sql
@@ -36,20 +36,28 @@ end;
 $$;
 
 
-CREATE TRIGGER jobs_notify
+CREATE TRIGGER jobs_notify_write
 AFTER insert
-OR
-UPDATE
 OR delete ON tml_switchboard.jobs FOR each ROW
 EXECUTE function tml_switchboard.notify_change ('job_id', 'dispatched_on_host_id');
 
 
-CREATE TRIGGER hosts_notify
+CREATE TRIGGER jobs_notify_update
+AFTER
+UPDATE ON tml_switchboard.jobs FOR each ROW WHEN (OLD.* IS DISTINCT FROM NEW.*)
+EXECUTE function tml_switchboard.notify_change ('job_id', 'dispatched_on_host_id');
+
+
+CREATE TRIGGER hosts_notify_write
 AFTER insert
-OR
+OR delete ON tml_switchboard.hosts FOR each ROW
+EXECUTE function tml_switchboard.notify_change ('host_id');
+
+
+CREATE TRIGGER hosts_notify_update
+AFTER
 UPDATE OF current_job,
 tags,
 owner_id,
-worker_instance_id
-OR delete ON tml_switchboard.hosts FOR each ROW
+worker_instance_id ON tml_switchboard.hosts FOR each ROW WHEN (OLD.* IS DISTINCT FROM NEW.*)
 EXECUTE function tml_switchboard.notify_change ('host_id');

--- a/switchboard/migrations/20260712034848_pg_notify_events.sql
+++ b/switchboard/migrations/20260712034848_pg_notify_events.sql
@@ -1,0 +1,55 @@
+-- Row-change wake-ups over LISTEN/NOTIFY on channel `tml_events`; see the
+-- CHANGE NOTIFICATIONS section of SCHEMA.sql for the payload contract.
+CREATE OR REPLACE FUNCTION tml_switchboard.notify_change () returns trigger language plpgsql AS $$
+declare
+    guc text := 'tml_switchboard.notify_rows_' || TG_TABLE_NAME;
+    n int := coalesce(nullif(current_setting(guc, true), ''), '0')::int + 1;
+    row_limit int := coalesce(
+        nullif(current_setting('tml_switchboard.notify_row_limit', true), ''),
+        '100')::int;
+    old_j jsonb;
+    new_j jsonb;
+    ks jsonb := '{}'::jsonb;
+    col text;
+    vals jsonb;
+begin
+    perform set_config(guc, n::text, true);
+    if n > row_limit then
+        perform pg_notify('tml_events',
+            jsonb_build_object('table', TG_TABLE_NAME)::text);
+        return null;
+    end if;
+    old_j := case when TG_OP <> 'INSERT' then to_jsonb(OLD) end;
+    new_j := case when TG_OP <> 'DELETE' then to_jsonb(NEW) end;
+    foreach col in array TG_ARGV loop
+        select coalesce(jsonb_agg(distinct v), '[]'::jsonb) into vals
+        from unnest(array[old_j -> col, new_j -> col]) as t (v)
+        where v is not null and v <> 'null'::jsonb;
+        if vals <> '[]'::jsonb then
+            ks := ks || jsonb_build_object(col, vals);
+        end if;
+    end loop;
+    perform pg_notify('tml_events',
+        jsonb_build_object('table', TG_TABLE_NAME, 'keys', ks)::text);
+    return null;
+end;
+$$;
+
+
+CREATE TRIGGER jobs_notify
+AFTER insert
+OR
+UPDATE
+OR delete ON tml_switchboard.jobs FOR each ROW
+EXECUTE function tml_switchboard.notify_change ('job_id', 'dispatched_on_host_id');
+
+
+CREATE TRIGGER hosts_notify
+AFTER insert
+OR
+UPDATE OF current_job,
+tags,
+owner_id,
+worker_instance_id
+OR delete ON tml_switchboard.hosts FOR each ROW
+EXECUTE function tml_switchboard.notify_change ('host_id');

--- a/switchboard/migrations/atlas.sum
+++ b/switchboard/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:l0X+PDwf+TMKxFAOYVLgXIn0OI6DLr8u/Z+XOLbLQns=
+h1:CkA0/em9ZWwA4JChaPg+UAaEEnb/fqY/6K3mYYpvYIk=
 00000000000001_base.sql h1:7OodY/qoessjRRoCAAX04fthKHTDNzzloQ4srKlxs+o=
 20260704040624_add_login_admission.sql h1:hYEzBBXagVmDVTtFsA1uosdNLKUi8JvitaMOFw/4jbk=
 20260708035542_everyone_subject.sql h1:eshPaeCj4UtkHWVuGTZHzsESVxK09Vy8ys5+ywA09pU=
@@ -6,3 +6,4 @@ h1:l0X+PDwf+TMKxFAOYVLgXIn0OI6DLr8u/Z+XOLbLQns=
 20260708153836_image_set_rename.sql h1:pYf4N6yTa0CPC58MA0bTMhNGEHFJfZKnnP91oxg9lFw=
 20260709090000_images_title.sql h1:6oX7RzSWvr+UEzFgcSPYcEo45hYxE9uHjb1n6sh3Pg0=
 20260709090001_remove_image_attrs_jsonb.sql h1:93BKzCkpTJ9YECRmz1fUvhFBadA1P6YLBvIerHyi9b0=
+20260712034848_pg_notify_events.sql h1:raJus90KyDnyUqK1W9HY7FtGGbwkMZm6QVD6DDG16io=

--- a/switchboard/migrations/atlas.sum
+++ b/switchboard/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:CkA0/em9ZWwA4JChaPg+UAaEEnb/fqY/6K3mYYpvYIk=
+h1:40dl18UgDz1aTzN5BAtSjQIFge9SmRm0v7wjvLRBZas=
 00000000000001_base.sql h1:7OodY/qoessjRRoCAAX04fthKHTDNzzloQ4srKlxs+o=
 20260704040624_add_login_admission.sql h1:hYEzBBXagVmDVTtFsA1uosdNLKUi8JvitaMOFw/4jbk=
 20260708035542_everyone_subject.sql h1:eshPaeCj4UtkHWVuGTZHzsESVxK09Vy8ys5+ywA09pU=
@@ -6,4 +6,4 @@ h1:CkA0/em9ZWwA4JChaPg+UAaEEnb/fqY/6K3mYYpvYIk=
 20260708153836_image_set_rename.sql h1:pYf4N6yTa0CPC58MA0bTMhNGEHFJfZKnnP91oxg9lFw=
 20260709090000_images_title.sql h1:6oX7RzSWvr+UEzFgcSPYcEo45hYxE9uHjb1n6sh3Pg0=
 20260709090001_remove_image_attrs_jsonb.sql h1:93BKzCkpTJ9YECRmz1fUvhFBadA1P6YLBvIerHyi9b0=
-20260712034848_pg_notify_events.sql h1:raJus90KyDnyUqK1W9HY7FtGGbwkMZm6QVD6DDG16io=
+20260712034848_pg_notify_events.sql h1:bohYlr4QqjynOXbIEIMlSZNkt978M6vDLynHzHryZ3s=

--- a/switchboard/src/config.rs
+++ b/switchboard/src/config.rs
@@ -238,6 +238,25 @@ pub struct ServiceConfig {
     /// sets scheduling latency, not liveness-detection cadence.
     #[serde(with = "humantime_serde")]
     pub supervisor_reconcile_interval: Duration,
+    /// Minimum spacing between event-driven scheduling passes under sustained
+    /// DB change notifications; `match_interval` remains the staleness ceiling.
+    #[serde(with = "humantime_serde", default = "default_scheduler_event_debounce")]
+    pub scheduler_event_debounce: Duration,
+    /// Minimum spacing between event-driven reconcile passes of a per-host
+    /// worker; `supervisor_reconcile_interval` remains the staleness ceiling.
+    #[serde(
+        with = "humantime_serde",
+        default = "default_supervisor_event_debounce"
+    )]
+    pub supervisor_event_debounce: Duration,
+}
+
+fn default_scheduler_event_debounce() -> Duration {
+    Duration::from_millis(250)
+}
+
+fn default_supervisor_event_debounce() -> Duration {
+    Duration::from_millis(100)
 }
 
 /// Load the switchboard configuration.
@@ -309,6 +328,8 @@ mod tests {
                 supervisor_ping_interval: Duration::from_secs(30),
                 supervisor_pong_dead: Duration::from_secs(60),
                 supervisor_reconcile_interval: Duration::from_secs(30),
+                scheduler_event_debounce: Duration::from_millis(250),
+                supervisor_event_debounce: Duration::from_millis(100),
             },
             oauth: OAuthConfig::default(),
             log_streaming: None,

--- a/switchboard/src/events.rs
+++ b/switchboard/src/events.rs
@@ -216,7 +216,14 @@ impl Debounced {
         }
     }
 
+    /// Cancellation-safe (fit for a `select!` arm): the cooldown is waited out
+    /// *before* any wake is consumed, and consumption happens synchronously in
+    /// the resolving poll — a `wait` future dropped mid-flight never loses a
+    /// pending wake.
     pub async fn wait(&mut self) {
+        if let Some(last_fired) = self.last_fired {
+            tokio::time::sleep_until(last_fired + self.cooldown).await;
+        }
         {
             let changed: Vec<_> = self
                 .subs
@@ -224,9 +231,6 @@ impl Debounced {
                 .map(|sub| Box::pin(sub.changed()))
                 .collect();
             futures_util::future::select_all(changed).await;
-        }
-        if let Some(last_fired) = self.last_fired {
-            tokio::time::sleep_until(last_fired + self.cooldown).await;
         }
         // Fold everything that accumulated while waiting into this firing;
         // the caller's imminent pass reads fresh state and covers it all.

--- a/switchboard/src/events.rs
+++ b/switchboard/src/events.rs
@@ -1,0 +1,414 @@
+//! In-process fan-out for the `tml_events` LISTEN/NOTIFY channel (see the
+//! CHANGE NOTIFICATIONS section of SCHEMA.sql for the emitting triggers and
+//! the payload contract).
+//!
+//! Notifications are edge-triggered wake-ups, not data carriers: a consumer's
+//! reaction to being woken is to re-read the database, exactly as on its
+//! periodic timer, which stays in place as the staleness fallback. This makes
+//! lost notifications (listener reconnect gaps) and duplicated or reordered
+//! ones harmless, and reduces rate limiting to coalescing plus a per-consumer
+//! debounce.
+//!
+//! One [`EventBus`] (and one Postgres `LISTEN` connection, via
+//! [`EventBus::listener`]) exists per process; each `LISTEN` pins a dedicated
+//! database connection, so per-consumer listeners would exhaust the pool. The
+//! subscription registry is ephemeral in-process routing state only — it is
+//! rebuilt from nothing on restart and correctness never depends on it.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures_util::FutureExt;
+use sqlx::PgPool;
+use sqlx::postgres::PgListener;
+use tokio::sync::watch;
+use tokio::time::Instant;
+use uuid::Uuid;
+
+const CHANNEL: &str = "tml_events";
+const RECONNECT_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(serde::Deserialize)]
+struct Event {
+    table: String,
+    /// Routing-key values, each rendered as its jsonb scalar. Absent/empty on
+    /// the bulk-write overflow form, which wakes every subscriber of `table`.
+    #[serde(default)]
+    keys: HashMap<String, Vec<serde_json::Value>>,
+}
+
+/// What a subscription matches: one table, either any row (`key: None`) or
+/// rows whose routing key `column` carries `value`. The emitting trigger
+/// decides which columns are routing keys; the primary key always is.
+///
+/// Clients must expect spurious notifications and ones that don't
+/// include even the primary, for instance in the case of bulk
+/// updates / inserts.
+pub struct EventFilter {
+    pub table: &'static str,
+    pub key: Option<(&'static str, Uuid)>,
+}
+
+#[derive(Clone, Default)]
+pub struct EventBus {
+    registry: Arc<Mutex<Registry>>,
+}
+
+#[derive(Default)]
+struct Registry {
+    tables: HashMap<String, TableSubs>,
+}
+
+#[derive(Default)]
+struct TableSubs {
+    wildcard: Vec<watch::Sender<()>>,
+    /// column -> value -> subscribers.
+    keyed: HashMap<String, HashMap<String, Vec<watch::Sender<()>>>>,
+}
+
+fn wake(tx: &watch::Sender<()>) -> bool {
+    tx.send(()).is_ok()
+}
+
+impl EventBus {
+    /// Register a subscription. It starts woken, so there is no gap between
+    /// subscribing and the consumer's first pass over current DB state.
+    pub fn subscribe(&self, filter: EventFilter) -> WakeSubscription {
+        let (tx, mut rx) = watch::channel(());
+        rx.mark_changed();
+        let mut registry = self.registry.lock().unwrap();
+        let table = registry.tables.entry(filter.table.to_string()).or_default();
+        match filter.key {
+            None => table.wildcard.push(tx),
+            Some((column, value)) => table
+                .keyed
+                .entry(column.to_string())
+                .or_default()
+                .entry(value.to_string())
+                .or_default()
+                .push(tx),
+        }
+        WakeSubscription { rx }
+    }
+
+    /// The long-running listener feeding this bus; spawn exactly one per
+    /// process. Reconnects forever; every (re)connect wakes all subscriptions,
+    /// since notifications during the gap are silently lost.
+    pub fn listener(&self, pool: PgPool) -> impl Future<Output = ()> + Send + 'static {
+        let bus = self.clone();
+        async move {
+            loop {
+                match PgListener::connect_with(&pool).await {
+                    Ok(mut listener) => match listener.listen(CHANNEL).await {
+                        Ok(()) => {
+                            bus.wake_all();
+                            bus.pump(&mut listener).await;
+                        }
+                        Err(e) => tracing::warn!("event listener LISTEN failed: {e}"),
+                    },
+                    Err(e) => tracing::warn!("event listener connect failed: {e}"),
+                }
+                tokio::time::sleep(RECONNECT_DELAY).await;
+            }
+        }
+    }
+
+    async fn pump(&self, listener: &mut PgListener) {
+        loop {
+            match listener.try_recv().await {
+                Ok(Some(notification)) => self.handle_payload(notification.payload()),
+                // The connection was lost and reestablished: a gap.
+                Ok(None) => self.wake_all(),
+                Err(e) => {
+                    tracing::warn!("event listener receive failed: {e}");
+                    return;
+                }
+            }
+        }
+    }
+
+    fn handle_payload(&self, payload: &str) {
+        let event: Event = match serde_json::from_str(payload) {
+            Ok(event) => event,
+            Err(e) => {
+                tracing::warn!("malformed tml_events payload: {e}");
+                return;
+            }
+        };
+        let mut registry = self.registry.lock().unwrap();
+        let Some(table) = registry.tables.get_mut(&event.table) else {
+            return;
+        };
+        table.wildcard.retain(wake);
+        if event.keys.is_empty() {
+            for by_value in table.keyed.values_mut() {
+                for subs in by_value.values_mut() {
+                    subs.retain(wake);
+                }
+            }
+        } else {
+            for (column, values) in &event.keys {
+                let Some(by_value) = table.keyed.get_mut(column) else {
+                    continue;
+                };
+                for value in values {
+                    let value = match value.as_str() {
+                        Some(s) => s.to_string(),
+                        None => value.to_string(),
+                    };
+                    if let Some(subs) = by_value.get_mut(&value) {
+                        subs.retain(wake);
+                    }
+                }
+            }
+        }
+    }
+
+    fn wake_all(&self) {
+        let mut registry = self.registry.lock().unwrap();
+        for table in registry.tables.values_mut() {
+            table.wildcard.retain(wake);
+            for by_value in table.keyed.values_mut() {
+                for subs in by_value.values_mut() {
+                    subs.retain(wake);
+                }
+            }
+        }
+    }
+}
+
+/// A coalescing wake handle: any number of matching events while the consumer
+/// is busy collapse into one pending wake.
+pub struct WakeSubscription {
+    rx: watch::Receiver<()>,
+}
+
+impl WakeSubscription {
+    /// Wait until at least one matching event arrived since the last call.
+    /// Never resolves if the bus is gone (the consumer's timer still drives
+    /// it).
+    pub async fn changed(&mut self) {
+        if self.rx.changed().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+/// Rate limiter over one or more subscriptions: leading-edge (an isolated
+/// event fires immediately), a minimum `cooldown` between firings under
+/// sustained events, and a trailing firing for events that arrived during the
+/// cooldown.
+pub struct Debounced {
+    subs: Vec<WakeSubscription>,
+    cooldown: Duration,
+    last_fired: Option<Instant>,
+}
+
+impl Debounced {
+    pub fn new(subs: Vec<WakeSubscription>, cooldown: Duration) -> Self {
+        assert!(!subs.is_empty());
+        Self {
+            subs,
+            cooldown,
+            last_fired: None,
+        }
+    }
+
+    pub async fn wait(&mut self) {
+        {
+            let changed: Vec<_> = self
+                .subs
+                .iter_mut()
+                .map(|sub| Box::pin(sub.changed()))
+                .collect();
+            futures_util::future::select_all(changed).await;
+        }
+        if let Some(last_fired) = self.last_fired {
+            tokio::time::sleep_until(last_fired + self.cooldown).await;
+        }
+        // Fold everything that accumulated while waiting into this firing;
+        // the caller's imminent pass reads fresh state and covers it all.
+        for sub in &mut self.subs {
+            let _ = sub.changed().now_or_never();
+        }
+        self.last_fired = Some(Instant::now());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn woken(sub: &mut WakeSubscription) -> bool {
+        sub.changed().now_or_never().is_some()
+    }
+
+    fn wildcard(bus: &EventBus, table: &'static str) -> WakeSubscription {
+        bus.subscribe(EventFilter { table, key: None })
+    }
+
+    fn keyed(
+        bus: &EventBus,
+        table: &'static str,
+        column: &'static str,
+        value: Uuid,
+    ) -> WakeSubscription {
+        bus.subscribe(EventFilter {
+            table,
+            key: Some((column, value)),
+        })
+    }
+
+    fn drain(subs: &mut [&mut WakeSubscription]) {
+        for sub in subs {
+            assert!(woken(sub), "a fresh subscription must start woken");
+        }
+    }
+
+    #[tokio::test]
+    async fn subscription_starts_woken_then_coalesces() {
+        let bus = EventBus::default();
+        let mut sub = wildcard(&bus, "jobs");
+        assert!(woken(&mut sub));
+        assert!(!woken(&mut sub));
+
+        bus.handle_payload(r#"{"table":"jobs","keys":{"job_id":["x"]}}"#);
+        bus.handle_payload(r#"{"table":"jobs","keys":{"job_id":["y"]}}"#);
+        assert!(woken(&mut sub), "events wake the subscription");
+        assert!(!woken(&mut sub), "two events coalesce into one wake");
+    }
+
+    #[tokio::test]
+    async fn keyed_and_wildcard_filtering() {
+        let bus = EventBus::default();
+        let hit = Uuid::new_v4();
+        let miss = Uuid::new_v4();
+        let mut wild = wildcard(&bus, "jobs");
+        let mut keyed_hit = keyed(&bus, "jobs", "job_id", hit);
+        let mut keyed_miss = keyed(&bus, "jobs", "job_id", miss);
+        let mut other_column = keyed(&bus, "jobs", "dispatched_on_host_id", hit);
+        let mut other_table = wildcard(&bus, "hosts");
+        drain(&mut [
+            &mut wild,
+            &mut keyed_hit,
+            &mut keyed_miss,
+            &mut other_column,
+            &mut other_table,
+        ]);
+
+        bus.handle_payload(&format!(
+            r#"{{"table":"jobs","keys":{{"job_id":["{hit}"]}}}}"#
+        ));
+        assert!(woken(&mut wild));
+        assert!(woken(&mut keyed_hit));
+        assert!(!woken(&mut keyed_miss));
+        assert!(!woken(&mut other_column));
+        assert!(!woken(&mut other_table));
+    }
+
+    #[tokio::test]
+    async fn multi_value_key_wakes_both_scopes() {
+        let bus = EventBus::default();
+        let old = Uuid::new_v4();
+        let new = Uuid::new_v4();
+        let mut sub_old = keyed(&bus, "jobs", "dispatched_on_host_id", old);
+        let mut sub_new = keyed(&bus, "jobs", "dispatched_on_host_id", new);
+        drain(&mut [&mut sub_old, &mut sub_new]);
+
+        bus.handle_payload(&format!(
+            r#"{{"table":"jobs","keys":{{"job_id":["j"],"dispatched_on_host_id":["{old}","{new}"]}}}}"#
+        ));
+        assert!(woken(&mut sub_old));
+        assert!(woken(&mut sub_new));
+    }
+
+    #[tokio::test]
+    async fn keyless_event_wakes_every_table_subscriber() {
+        let bus = EventBus::default();
+        let mut wild = wildcard(&bus, "hosts");
+        let mut keyed_sub = keyed(&bus, "hosts", "host_id", Uuid::new_v4());
+        let mut other_table = wildcard(&bus, "jobs");
+        drain(&mut [&mut wild, &mut keyed_sub, &mut other_table]);
+
+        bus.handle_payload(r#"{"table":"hosts"}"#);
+        assert!(woken(&mut wild));
+        assert!(woken(&mut keyed_sub));
+        assert!(!woken(&mut other_table));
+    }
+
+    #[tokio::test]
+    async fn wake_all_wakes_everything() {
+        let bus = EventBus::default();
+        let mut wild = wildcard(&bus, "jobs");
+        let mut keyed_sub = keyed(&bus, "hosts", "host_id", Uuid::new_v4());
+        drain(&mut [&mut wild, &mut keyed_sub]);
+
+        bus.wake_all();
+        assert!(woken(&mut wild));
+        assert!(woken(&mut keyed_sub));
+    }
+
+    #[tokio::test]
+    async fn malformed_payload_wakes_nothing() {
+        let bus = EventBus::default();
+        let mut sub = wildcard(&bus, "jobs");
+        drain(&mut [&mut sub]);
+
+        bus.handle_payload("not json");
+        bus.handle_payload(r#"{"keys":{}}"#);
+        assert!(!woken(&mut sub));
+    }
+
+    #[tokio::test]
+    async fn dropped_subscriptions_are_pruned() {
+        let bus = EventBus::default();
+        let sub = wildcard(&bus, "jobs");
+        drop(sub);
+        bus.handle_payload(r#"{"table":"jobs","keys":{"job_id":["x"]}}"#);
+        let registry = bus.registry.lock().unwrap();
+        assert!(registry.tables["jobs"].wildcard.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn debounce_is_leading_edge_with_cooldown() {
+        let cooldown = Duration::from_secs(1);
+        let bus = EventBus::default();
+        let sub = wildcard(&bus, "jobs");
+        let mut debounced = Debounced::new(vec![sub], cooldown);
+
+        // Leading edge: the initial (start-woken) firing is immediate.
+        let start = Instant::now();
+        debounced.wait().await;
+        assert_eq!(Instant::now() - start, Duration::ZERO);
+
+        // An event right after a firing is held back to the cooldown.
+        bus.handle_payload(r#"{"table":"jobs","keys":{"job_id":["x"]}}"#);
+        debounced.wait().await;
+        assert_eq!(Instant::now() - start, cooldown);
+
+        // After a quiet stretch longer than the cooldown, leading edge again.
+        tokio::time::sleep(cooldown * 5).await;
+        bus.handle_payload(r#"{"table":"jobs","keys":{"job_id":["y"]}}"#);
+        let quiet = Instant::now();
+        debounced.wait().await;
+        assert_eq!(Instant::now() - quiet, Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn debounce_folds_accumulated_wakes_into_one_firing() {
+        let bus = EventBus::default();
+        let sub_a = wildcard(&bus, "jobs");
+        let sub_b = wildcard(&bus, "hosts");
+        let mut debounced = Debounced::new(vec![sub_a, sub_b], Duration::from_secs(1));
+
+        bus.handle_payload(r#"{"table":"jobs","keys":{"job_id":["x"]}}"#);
+        bus.handle_payload(r#"{"table":"hosts","keys":{"host_id":["y"]}}"#);
+        debounced.wait().await;
+
+        // Both wakes (and the start-woken state) folded into the firing above:
+        // nothing further is pending.
+        assert!(debounced.wait().now_or_never().is_none());
+    }
+}

--- a/switchboard/src/lib.rs
+++ b/switchboard/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod auth;
 pub mod client_addr;
 pub mod config;
+pub mod events;
 pub(crate) mod http_error;
 pub mod log_streaming;
 pub mod matcher;

--- a/switchboard/src/routes/hosts.rs
+++ b/switchboard/src/routes/hosts.rs
@@ -177,11 +177,13 @@ pub async fn connect(
         supervisor_ping_interval: state.config().service.supervisor_ping_interval,
         supervisor_pong_dead: state.config().service.supervisor_pong_dead,
         supervisor_reconcile_interval: state.config().service.supervisor_reconcile_interval,
+        supervisor_event_debounce: state.config().service.supervisor_event_debounce,
     };
 
     // Shared with the worker so it can mint per-job write tokens and provision
     // streams at dispatch; `None` when log streaming is disabled.
     let log_streaming = state.log_streaming().cloned();
+    let event_bus = state.event_bus().clone();
 
     let mut response = ws.protocols([TREADMILL_WEBSOCKET_PROTOCOL]).on_upgrade(
         move |mut web_socket| async move {
@@ -212,6 +214,7 @@ pub async fn connect(
                     web_socket,
                     ws_worker_config,
                     log_streaming,
+                    event_bus,
                 )
                 .await
             });

--- a/switchboard/src/scheduler.rs
+++ b/switchboard/src/scheduler.rs
@@ -5,8 +5,9 @@
 //! database** — it never holds an in-process handle to a worker — so the two can
 //! be distributed across processes later. The scheduler writes the assignment
 //! (`hosts.current_job` + `jobs.job_state = 'assigned'`); the host's own worker
-//! observes it and issues `StartJob`. For now this is poll-based; Postgres
-//! `LISTEN`/`NOTIFY` can replace the polling later without schema changes.
+//! observes it and issues `StartJob`. Passes run when a jobs/hosts change
+//! notification arrives (debounced; see [`crate::events`]), with the periodic
+//! `match_interval` timer as the staleness fallback.
 //!
 //! Each pass:
 //!   1. streams `queued` jobs oldest-first;
@@ -27,18 +28,23 @@ use uuid::Uuid;
 use crate::audit::model::{Host as AuditHost, Job as AuditJob, Subject as AuditSubject};
 use crate::audit::{self, SYSTEM_ACTOR_ID, events};
 use crate::auth::engine::{self, HostPermission};
+use crate::events::{Debounced, EventBus, EventFilter};
 use crate::matcher::{self, TargetCandidate};
 use crate::sql;
 use crate::sql::job::{ImageResolveError, SqlJobState};
 
-/// Periodically dispatches queued jobs onto eligible hosts. Holds only a pool
-/// handle (DB-only coordination).
+/// Dispatches queued jobs onto eligible hosts. Holds only a pool handle and
+/// change-notification subscriptions (DB-only coordination).
 pub struct Scheduler {
     pool: PgPool,
-    /// Interval between scheduling passes.
+    /// Interval between scheduling passes when no change notification arrives.
     match_interval: TimeDelta,
     /// How recently a host must have heartbeat to be considered live.
     host_liveness_timeout: TimeDelta,
+    /// Debounced wake on any jobs/hosts change. Filtering finer than
+    /// table-wide isn't worth it here: a pass with nothing queued is one
+    /// indexed query.
+    wake: Debounced,
 }
 
 /// Outcome of attempting to place one job on one candidate host.
@@ -58,16 +64,36 @@ enum AssignOutcome {
 }
 
 impl Scheduler {
-    pub fn new(pool: PgPool, match_interval: TimeDelta, host_liveness_timeout: TimeDelta) -> Self {
+    pub fn new(
+        pool: PgPool,
+        match_interval: TimeDelta,
+        host_liveness_timeout: TimeDelta,
+        event_bus: &EventBus,
+        event_debounce: std::time::Duration,
+    ) -> Self {
+        let wake = Debounced::new(
+            vec![
+                event_bus.subscribe(EventFilter {
+                    table: "jobs",
+                    key: None,
+                }),
+                event_bus.subscribe(EventFilter {
+                    table: "hosts",
+                    key: None,
+                }),
+            ],
+            event_debounce,
+        );
         Self {
             pool,
             match_interval,
             host_liveness_timeout,
+            wake,
         }
     }
 
     /// Run the scheduling loop forever (until the task is dropped).
-    pub async fn run(self) {
+    pub async fn run(mut self) {
         let period = self
             .match_interval
             .to_std()
@@ -75,7 +101,10 @@ impl Scheduler {
         let mut ticker = tokio::time::interval(period);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
-            ticker.tick().await;
+            tokio::select! {
+                _ = ticker.tick() => {}
+                _ = self.wake.wait() => {}
+            }
             if let Err(e) = self.tick().await {
                 tracing::error!("scheduler pass failed: {e:?}");
             }
@@ -316,7 +345,13 @@ mod tests {
     use treadmill_rs::image::{Digest, media_types};
 
     fn scheduler(pool: PgPool) -> Scheduler {
-        Scheduler::new(pool, Duration::seconds(1), Duration::seconds(60))
+        Scheduler::new(
+            pool,
+            Duration::seconds(1),
+            Duration::seconds(60),
+            &EventBus::default(),
+            std::time::Duration::from_millis(10),
+        )
     }
 
     /// A deterministic distinct digest per `seed`.
@@ -1128,6 +1163,64 @@ mod tests {
             job_termination(&pool, job).await?.as_deref(),
             Some("image_error")
         );
+        Ok(())
+    }
+
+    /// A change notification, not the `match_interval` timer, drives the pass:
+    /// with the timer effectively disabled, an enqueue after startup must still
+    /// be assigned promptly.
+    #[sqlx::test(migrations = "./migrations")]
+    #[ignore = "needs Postgres; run via `cargo nextest run --run-ignored only`"]
+    async fn enqueue_event_drives_a_pass_without_the_timer(pool: PgPool) -> anyhow::Result<()> {
+        let user = insert_user(&pool).await?;
+        let token = insert_token(&pool, user).await?;
+        let host = insert_live_host(&pool, user, &["arch=arm64"]).await?;
+        let (_, img) = register_image(&pool, user, 1, true).await?;
+
+        let bus = EventBus::default();
+        tokio::spawn(bus.listener(pool.clone()));
+        tokio::spawn(
+            Scheduler::new(
+                pool.clone(),
+                Duration::hours(1),
+                Duration::seconds(60),
+                &bus,
+                std::time::Duration::from_millis(10),
+            )
+            .run(),
+        );
+
+        // Wait until the listener demonstrably delivers wakes (its LISTEN may
+        // not be up yet; a write committed before that is a lost notification,
+        // which only the timer would cover).
+        let mut probe = bus.subscribe(EventFilter {
+            table: "hosts",
+            key: Some(("host_id", host)),
+        });
+        probe.changed().await;
+        loop {
+            sqlx::query("update tml_switchboard.hosts set tags = tags where host_id = $1")
+                .bind(host)
+                .execute(&pool)
+                .await?;
+            if tokio::time::timeout(std::time::Duration::from_millis(200), probe.changed())
+                .await
+                .is_ok()
+            {
+                break;
+            }
+        }
+
+        let job = enqueue_image(&pool, token, img, &["arch=arm64"], &[]).await?;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        while job_state(&pool, job).await? != "assigned" {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "the enqueue notification did not drive a scheduling pass"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(host_current_job(&pool, host).await?, Some(job));
         Ok(())
     }
 

--- a/switchboard/src/scheduler.rs
+++ b/switchboard/src/scheduler.rs
@@ -1192,17 +1192,22 @@ mod tests {
 
         // Wait until the listener demonstrably delivers wakes (its LISTEN may
         // not be up yet; a write committed before that is a lost notification,
-        // which only the timer would cover).
+        // which only the timer would cover). Probes a throwaway host so the
+        // eligible host's tags stay intact.
+        let probe_host = insert_host(&pool, user, &[], None).await?;
         let mut probe = bus.subscribe(EventFilter {
             table: "hosts",
-            key: Some(("host_id", host)),
+            key: Some(("host_id", probe_host)),
         });
         probe.changed().await;
         loop {
-            sqlx::query("update tml_switchboard.hosts set tags = tags where host_id = $1")
-                .bind(host)
-                .execute(&pool)
-                .await?;
+            sqlx::query(
+                "update tml_switchboard.hosts set tags = array[md5(random()::text)] \
+                 where host_id = $1",
+            )
+            .bind(probe_host)
+            .execute(&pool)
+            .await?;
             if tokio::time::timeout(std::time::Duration::from_millis(200), probe.changed())
                 .await
                 .is_ok()

--- a/switchboard/src/serve.rs
+++ b/switchboard/src/serve.rs
@@ -167,6 +167,8 @@ pub async fn serve(serve_command: ServeCommand) -> anyhow::Result<()> {
         pg_pool.clone(),
         config.service.match_interval,
         config.service.host_liveness_timeout,
+        &event_bus,
+        config.service.scheduler_event_debounce,
     );
     tokio::spawn(scheduler.run());
 

--- a/switchboard/src/serve.rs
+++ b/switchboard/src/serve.rs
@@ -1,4 +1,5 @@
 use crate::config::{DatabaseConfig, DatabaseCredentials, SwitchboardConfig};
+use crate::events::EventBus;
 use crate::log_streaming::{LogStreaming, NatsLogStreamProvisioner};
 use crate::registry::{OciRegistryClient, RegistryClient};
 use anyhow::Context;
@@ -20,6 +21,10 @@ pub struct AppStateInner {
     /// feature: jobs dispatch without a streaming destination. Built once at
     /// startup and shared with every supervisor worker.
     log_streaming: Option<LogStreaming>,
+    /// The per-process fan-out for `tml_events` DB change notifications. In
+    /// production [`serve`] spawns its listener; test-constructed states carry
+    /// a bus nothing feeds, so consumers fall back to their timers.
+    event_bus: EventBus,
 }
 
 impl AppStateInner {
@@ -35,13 +40,22 @@ impl AppStateInner {
     pub fn log_streaming(&self) -> Option<&LogStreaming> {
         self.log_streaming.as_ref()
     }
+    pub fn event_bus(&self) -> &EventBus {
+        &self.event_bus
+    }
 }
 
 #[derive(Clone)]
 pub struct AppState(Arc<AppStateInner>);
 impl AppState {
     pub fn new(pg_pool: PgPool, config: SwitchboardConfig) -> Self {
-        Self::with_components(pg_pool, config, Arc::new(OciRegistryClient::new()), None)
+        Self::with_components(
+            pg_pool,
+            config,
+            Arc::new(OciRegistryClient::new()),
+            None,
+            EventBus::default(),
+        )
     }
 
     /// Construct an [`AppState`] with an explicit registry client. Used by
@@ -52,23 +66,25 @@ impl AppState {
         config: SwitchboardConfig,
         registry: Arc<dyn RegistryClient>,
     ) -> Self {
-        Self::with_components(pg_pool, config, registry, None)
+        Self::with_components(pg_pool, config, registry, None, EventBus::default())
     }
 
     /// Construct an [`AppState`] from all of its injectable components. The
     /// production entry point ([`serve`]) uses this to attach the log-streaming
-    /// provisioner it builds at startup.
+    /// provisioner and the fed event bus it builds at startup.
     pub fn with_components(
         pg_pool: PgPool,
         config: SwitchboardConfig,
         registry: Arc<dyn RegistryClient>,
         log_streaming: Option<LogStreaming>,
+        event_bus: EventBus,
     ) -> Self {
         AppState(Arc::new(AppStateInner {
             pg_pool,
             config,
             registry,
             log_streaming,
+            event_bus,
         }))
     }
 }
@@ -139,6 +155,11 @@ pub async fn serve(serve_command: ServeCommand) -> anyhow::Result<()> {
 
     let bind_address = config.server.bind_address;
 
+    // The process-wide change-notification fan-out and its single LISTEN
+    // connection (see `crate::events`).
+    let event_bus = EventBus::default();
+    tokio::spawn(event_bus.listener(pg_pool.clone()));
+
     // Spawn the job scheduler. It coordinates with the per-host supervisor
     // workers entirely through the database (no in-process channel), so it just
     // needs its own pool handle; see `crate::scheduler`.
@@ -174,6 +195,7 @@ pub async fn serve(serve_command: ServeCommand) -> anyhow::Result<()> {
         config,
         Arc::new(OciRegistryClient::new()),
         log_streaming,
+        event_bus,
     );
     let router = super::routes::build_router(app_state);
 

--- a/switchboard/src/supervisor_ws_worker.rs
+++ b/switchboard/src/supervisor_ws_worker.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 use crate::audit::model::{Host as AuditHost, Job as AuditJob, Subject as AuditSubject};
 use crate::audit::{self, SYSTEM_ACTOR_ID, events};
+use crate::events::{Debounced, EventBus, EventFilter};
 use crate::log_streaming::LogStreaming;
 use crate::sql;
 
@@ -62,12 +63,16 @@ pub struct SupervisorWSWorkerConfig {
     /// inbound status response), so it only fires to cover quiet stretches. A
     /// reconcile never issues a `StatusRequest` itself — it reads the in-memory
     /// status cache that the ping-driven `StatusRequest` and (later) the event
-    /// stream keep fresh — so a future Postgres pub/sub trigger costs no round
-    /// trip.
+    /// stream keep fresh — so an event-bus wake costs no round trip.
     ///
     /// [`reconcile`]: SupervisorWSWorker::reconcile
     #[serde(with = "humantime_serde")]
     pub supervisor_reconcile_interval: Duration,
+    /// Minimum spacing between event-driven reconcile passes (the cooldown of
+    /// the worker's debounced change-notification wake);
+    /// `supervisor_reconcile_interval` remains the staleness ceiling.
+    #[serde(with = "humantime_serde")]
+    pub supervisor_event_debounce: Duration,
 }
 
 /// DB-side identity and configuration for one supervisor worker, deliberately
@@ -98,12 +103,17 @@ struct WorkerCtx {
 pub struct SupervisorWSWorker<S: SupervisorSocket> {
     ctx: WorkerCtx,
     socket: S,
+    /// Debounced wake on changes to this host's row or to jobs dispatched on
+    /// it (`dispatched_on_host_id`); the latter is how a user terminate or a
+    /// deadline change reaches the worker without waiting out the reconcile
+    /// timer.
+    wake: Debounced,
     /// The supervisor's last reported status (`J_sup`), refreshed out-of-band by
     /// the periodic `StatusRequest`/`StatusResponse` round trip (and, later, the
     /// event stream). `reconcile` converges against *this* cached value rather
     /// than forcing a fresh round trip, so a reconcile triggered by anything
-    /// (the timer, a status response, a future Postgres pub/sub notification) is
-    /// a pure DB operation. `None` until the first status is seen, during which
+    /// (the timer, a status response, an event-bus wake) is a pure DB
+    /// operation. `None` until the first status is seen, during which
     /// reconcile is a no-op (the actual supervisor state is still unknown).
     last_seen_status: Option<ReportedSupervisorStatus>,
 }
@@ -438,15 +448,16 @@ async fn resolve_assigned_or_running(
 }
 
 impl<S: SupervisorSocket> SupervisorWSWorker<S> {
-    #[tracing::instrument(skip(pool, socket, config, log_streaming))]
+    #[tracing::instrument(skip(pool, socket, config, log_streaming, event_bus))]
     pub async fn run(
         pool: PgPool,
         host_id: Uuid,
         socket: S,
         config: SupervisorWSWorkerConfig,
         log_streaming: Option<LogStreaming>,
+        event_bus: EventBus,
     ) {
-        match Self::run_inner(pool, host_id, socket, config, log_streaming).await {
+        match Self::run_inner(pool, host_id, socket, config, log_streaming, event_bus).await {
             Ok(()) => {
                 tracing::info!("SupervisorWSWorker::run terminated successfully.");
             }
@@ -472,6 +483,7 @@ impl<S: SupervisorSocket> SupervisorWSWorker<S> {
         socket: S,
         config: SupervisorWSWorkerConfig,
         log_streaming: Option<LogStreaming>,
+        event_bus: EventBus,
     ) -> WorkerResult<()> {
         // A supervisor has just opened a new WebSocket connection for this host
         // and successfully authenticated. This might be because it's a new
@@ -501,6 +513,20 @@ impl<S: SupervisorSocket> SupervisorWSWorker<S> {
         // authenticated:
         let worker_instance_id = WorkerCtx::obtain_worker_instance_id(&pool, host_id).await?;
 
+        let wake = Debounced::new(
+            vec![
+                event_bus.subscribe(EventFilter {
+                    table: "hosts",
+                    key: Some(("host_id", host_id)),
+                }),
+                event_bus.subscribe(EventFilter {
+                    table: "jobs",
+                    key: Some(("dispatched_on_host_id", host_id)),
+                }),
+            ],
+            config.supervisor_event_debounce,
+        );
+
         // Now, using this ID, construct the worker instance:
         let mut worker = SupervisorWSWorker {
             ctx: WorkerCtx {
@@ -511,6 +537,7 @@ impl<S: SupervisorSocket> SupervisorWSWorker<S> {
                 log_streaming,
             },
             socket,
+            wake,
             last_seen_status: None,
         };
 
@@ -560,9 +587,9 @@ impl<S: SupervisorSocket> SupervisorWSWorker<S> {
     /// [`last_seen_status`] cache, **not** by issuing a fresh `StatusRequest`:
     /// the cache is refreshed out-of-band by the periodic status round trip (and,
     /// later, the event stream), so a reconcile is a pure DB operation regardless
-    /// of what triggered it (the timer, an inbound status response, a future
-    /// Postgres pub/sub notification). While the cache is `None` (no status seen
-    /// yet) reconcile is a no-op — the actual state is unknown.
+    /// of what triggered it (the timer, an inbound status response, an event-bus
+    /// wake). While the cache is `None` (no status seen yet) reconcile is a
+    /// no-op — the actual state is unknown.
     ///
     /// Let `J_sb = hosts.current_job`, `S = its job_state`, and `J_sup` = the
     /// reported `OngoingJob` id, if any. The convergence table, split by `S`
@@ -1182,6 +1209,16 @@ impl<S: SupervisorSocket> SupervisorWSWorker<S> {
                     self.reconcile().await?;
                 }
 
+                // A change notification for this host's row or its dispatched
+                // job: converge now (this is what makes a fresh assignment or
+                // a user terminate near-instant), and reset the dedicated
+                // timer (this counts as the period's reconcile).
+                _ = self.wake.wait() => {
+                    tracing::trace!("reconciling on change notification");
+                    self.reconcile().await?;
+                    reconcile_interval.reset();
+                }
+
                 // Timeout for waiting on a PONG message from the supervisor. If
                 // we haven't received one within the timeout and this fires, it
                 // means we should consider the connection dead.
@@ -1237,7 +1274,22 @@ mod tests {
             // here means the ping/pong/inbound tests don't see stray reconcile
             // ticks (their reconciles, if any, are driven directly).
             supervisor_reconcile_interval: Duration::from_secs(3600),
+            supervisor_event_debounce: Duration::from_millis(10),
         }
+    }
+
+    /// A `wake` for directly-constructed workers: its bus is dropped
+    /// immediately, so it never fires beyond the initial subscribe-time wake
+    /// (which the reconcile-driven tests never poll).
+    fn idle_wake() -> Debounced {
+        let bus = EventBus::default();
+        Debounced::new(
+            vec![bus.subscribe(EventFilter {
+                table: "jobs",
+                key: None,
+            })],
+            Duration::from_secs(3600),
+        )
     }
 
     /// Minimal `SupervisorSocket` impl used by tests that don't exercise the
@@ -1363,6 +1415,7 @@ mod tests {
                 log_streaming: None,
             },
             socket: NoSocket,
+            wake: idle_wake(),
             last_seen_status: None,
         }
     }
@@ -1390,6 +1443,7 @@ mod tests {
                 log_streaming: None,
             },
             socket,
+            wake: idle_wake(),
             last_seen_status: None,
         };
         (to_worker, from_worker, worker)
@@ -1767,7 +1821,14 @@ mod tests {
 
         tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            SupervisorWSWorker::run(pool, host_id, socket, worker_config(50, 250), None),
+            SupervisorWSWorker::run(
+                pool,
+                host_id,
+                socket,
+                worker_config(50, 250),
+                None,
+                EventBus::default(),
+            ),
         )
         .await
         .expect("worker should return promptly after peer Close");
@@ -1786,7 +1847,14 @@ mod tests {
 
         tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            SupervisorWSWorker::run(pool, host_id, socket, worker_config(50, 250), None),
+            SupervisorWSWorker::run(
+                pool,
+                host_id,
+                socket,
+                worker_config(50, 250),
+                None,
+                EventBus::default(),
+            ),
         )
         .await
         .expect("worker should return promptly on socket stream end");
@@ -1820,6 +1888,7 @@ mod tests {
             socket,
             worker_config(50, 5_000),
             None,
+            EventBus::default(),
         ));
 
         // The worker marks the host live on connect (before the first ping).
@@ -1894,7 +1963,14 @@ mod tests {
         // 50ms ping cadence, 5s dead-pong deadline — the deadline is wide
         // enough that the dead-peer guard never fires during this test.
         let cfg = worker_config(50, 5_000);
-        let jh = tokio::spawn(SupervisorWSWorker::run(pool, host_id, socket, cfg, None));
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool,
+            host_id,
+            socket,
+            cfg,
+            None,
+            EventBus::default(),
+        ));
 
         for n in 1..=3 {
             // The worker also emits `StatusRequest` (Text) frames on connect and
@@ -1927,7 +2003,14 @@ mod tests {
 
         // Tight deadline — worker should declare the peer dead within ~200ms.
         let cfg = worker_config(50, 200);
-        let jh = tokio::spawn(SupervisorWSWorker::run(pool, host_id, socket, cfg, None));
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool,
+            host_id,
+            socket,
+            cfg,
+            None,
+            EventBus::default(),
+        ));
 
         // We never respond with Pongs; the worker must give up on its own.
         // Generous outer bound: pong-dead (200ms) + slack for scheduling/DB
@@ -1958,7 +2041,14 @@ mod tests {
         // false dead-peer detection to flake this liveness check (the exact
         // threshold is pinned by `run_exits_when_no_pong_within_dead_threshold`).
         let cfg = worker_config(50, 400);
-        let jh = tokio::spawn(SupervisorWSWorker::run(pool, host_id, socket, cfg, None));
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool,
+            host_id,
+            socket,
+            cfg,
+            None,
+            EventBus::default(),
+        ));
 
         for n in 1..=16 {
             // Skip the `StatusRequest` (Text) frames the worker also emits; we
@@ -1991,6 +2081,114 @@ mod tests {
         Ok(())
     }
 
+    /// A change notification — here a user terminate writing the job row —
+    /// drives a reconcile through `run_loop` while both the reconcile timer
+    /// (disabled in `worker_config`) and the ping cadence (60s) are out of the
+    /// picture: the worker must emit `StopJob` promptly.
+    #[sqlx::test(migrations = "./migrations")]
+    #[ignore = "needs Postgres; run via `cargo nextest run --run-ignored only`"]
+    async fn terminate_event_drives_reconcile_without_timer(pool: PgPool) -> anyhow::Result<()> {
+        use treadmill_rs::api::switchboard_supervisor::SupervisorToSwitchboard;
+
+        let host_id = insert_host(&pool).await?;
+        let user_id = insert_user(&pool).await?;
+        let token_id = insert_token(&pool, user_id).await?;
+        let job_id = insert_job(&pool, token_id, host_id, "ready", 0).await?;
+        set_current_job(&pool, host_id, Some(job_id)).await?;
+
+        let bus = EventBus::default();
+        tokio::spawn(bus.listener(pool.clone()));
+
+        let (to_worker, mut from_worker, socket) = scripted_socket();
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool.clone(),
+            host_id,
+            socket,
+            worker_config(60_000, 600_000),
+            None,
+            bus.clone(),
+        ));
+
+        // Seed the worker's status cache out-of-band: the supervisor reports
+        // the assigned job running, so reconciles are aligned until the
+        // terminate lands.
+        let seed = serde_json::to_string(&SupervisorToSwitchboard::SupervisorEvent(
+            SupervisorEvent::JobEvent {
+                job_id,
+                event: SupervisorJobEvent::StateTransition {
+                    new_state: RunningJobState::Ready,
+                    status_message: None,
+                },
+            },
+        ))?;
+        to_worker
+            .send(Ok(ws::Message::Text(seed.into())))
+            .expect("inbound channel must stay open");
+
+        // Wait until the event listener demonstrably delivers wakes (its
+        // LISTEN may not be up yet), probing a throwaway host so the state
+        // under test stays untouched.
+        let probe_host = insert_host(&pool).await?;
+        let mut probe = bus.subscribe(EventFilter {
+            table: "hosts",
+            key: Some(("host_id", probe_host)),
+        });
+        probe.changed().await;
+        loop {
+            sqlx::query(
+                "update tml_switchboard.hosts set tags = array[md5(random()::text)] \
+                 where host_id = $1",
+            )
+            .bind(probe_host)
+            .execute(&pool)
+            .await?;
+            if tokio::time::timeout(std::time::Duration::from_millis(200), probe.changed())
+                .await
+                .is_ok()
+            {
+                break;
+            }
+        }
+
+        sqlx::query(
+            "update tml_switchboard.jobs set terminate_requested_at = now() where job_id = $1",
+        )
+        .bind(job_id)
+        .execute(&pool)
+        .await?;
+
+        // The jobs event (routed via dispatched_on_host_id) must wake the
+        // worker into a reconcile that emits StopJob; skip the StatusRequest
+        // frames the worker also produces.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let remaining = deadline
+                .checked_duration_since(tokio::time::Instant::now())
+                .expect("no StopJob emitted in response to the terminate event");
+            let msg = tokio::time::timeout(remaining, from_worker.recv())
+                .await
+                .expect("no StopJob emitted in response to the terminate event")
+                .expect("from_worker channel must remain open while worker runs");
+            if let ws::Message::Text(text) = msg
+                && let SwitchboardToSupervisor::StopJob(stop) =
+                    serde_json::from_str::<SwitchboardToSupervisor>(&text)
+                        .expect("outbound must be valid SwitchboardToSupervisor JSON")
+            {
+                assert_eq!(stop.job_id, job_id);
+                break;
+            }
+        }
+
+        to_worker
+            .send(Ok(ws::Message::Close(None)))
+            .expect("inbound channel must stay open");
+        tokio::time::timeout(std::time::Duration::from_secs(2), jh)
+            .await
+            .expect("worker should return promptly after Close")
+            .expect("worker task should not panic");
+        Ok(())
+    }
+
     // -- non-Close inbound frames must not panic the run-loop ----------------
     //
     // These pin down what each inbound frame type does at the worker layer:
@@ -2011,7 +2209,14 @@ mod tests {
         // Wide ping cadence / dead-pong deadline so neither fires during this
         // test — we only care that an inbound Ping doesn't take down the loop.
         let cfg = worker_config(60_000, 600_000);
-        let jh = tokio::spawn(SupervisorWSWorker::run(pool, host_id, socket, cfg, None));
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool,
+            host_id,
+            socket,
+            cfg,
+            None,
+            EventBus::default(),
+        ));
 
         // In production the Pong reply is emitted by the tungstenite framing
         // layer wrapped by axum's WebSocket; the application-level worker only
@@ -2041,7 +2246,14 @@ mod tests {
         let (to_worker, _from_worker, socket) = scripted_socket();
 
         let cfg = worker_config(60_000, 600_000);
-        let jh = tokio::spawn(SupervisorWSWorker::run(pool, host_id, socket, cfg, None));
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool,
+            host_id,
+            socket,
+            cfg,
+            None,
+            EventBus::default(),
+        ));
 
         // Unsolicited Pong — must not panic the run loop.
         to_worker
@@ -2068,7 +2280,14 @@ mod tests {
         let (to_worker, _from_worker, socket) = scripted_socket();
 
         let cfg = worker_config(60_000, 600_000);
-        let jh = tokio::spawn(SupervisorWSWorker::run(pool, host_id, socket, cfg, None));
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool,
+            host_id,
+            socket,
+            cfg,
+            None,
+            EventBus::default(),
+        ));
 
         // The protocol is JSON-over-Text; Binary frames aren't part of it.
         // The loop should log and continue rather than panic.
@@ -2093,7 +2312,14 @@ mod tests {
         let (to_worker, _from_worker, socket) = scripted_socket();
 
         let cfg = worker_config(60_000, 600_000);
-        let jh = tokio::spawn(SupervisorWSWorker::run(pool, host_id, socket, cfg, None));
+        let jh = tokio::spawn(SupervisorWSWorker::run(
+            pool,
+            host_id,
+            socket,
+            cfg,
+            None,
+            EventBus::default(),
+        ));
 
         // Garbage that won't deserialize as a `switchboard_supervisor::Message`.
         // Until step 3 wires up real dispatch, the only contract we need is

--- a/switchboard/src/supervisor_ws_worker.rs
+++ b/switchboard/src/supervisor_ws_worker.rs
@@ -1213,7 +1213,14 @@ impl<S: SupervisorSocket> SupervisorWSWorker<S> {
                 // job: converge now (this is what makes a fresh assignment or
                 // a user terminate near-instant), and reset the dedicated
                 // timer (this counts as the period's reconcile).
-                _ = self.wake.wait() => {
+                //
+                // Gated on a populated status cache: reconciling against `None`
+                // is a no-op, so consuming a wake before the first status
+                // report would swallow the edge — a terminate landing right
+                // after (re)connect would then wait out the next status
+                // refresh. Left unpolled, the wake stays pending (`Debounced`
+                // is cancellation-safe) and fires once the cache exists.
+                _ = self.wake.wait(), if self.last_seen_status.is_some() => {
                     tracing::trace!("reconciling on change notification");
                     self.reconcile().await?;
                     reconcile_interval.reset();

--- a/switchboard/tests/common/mod.rs
+++ b/switchboard/tests/common/mod.rs
@@ -54,6 +54,8 @@ pub fn test_config(gh_uri: &str) -> SwitchboardConfig {
             supervisor_ping_interval: std::time::Duration::from_secs(30),
             supervisor_pong_dead: std::time::Duration::from_secs(60),
             supervisor_reconcile_interval: std::time::Duration::from_secs(30),
+            scheduler_event_debounce: std::time::Duration::from_millis(250),
+            supervisor_event_debounce: std::time::Duration::from_millis(100),
         },
         oauth: OAuthConfig {
             github: Some(GitHubOAuthConfig {

--- a/switchboard/tests/host_routes.rs
+++ b/switchboard/tests/host_routes.rs
@@ -14,6 +14,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use treadmill_rs::api::switchboard::hosts::HostInfo;
+use treadmill_switchboard::events::EventBus;
 use treadmill_switchboard::registry::OciRegistryClient;
 use treadmill_switchboard::serve::AppState;
 
@@ -26,6 +27,7 @@ fn test_state(pool: PgPool) -> AppState {
         test_config_mock(),
         Arc::new(OciRegistryClient::new()),
         None,
+        EventBus::default(),
     )
 }
 

--- a/switchboard/tests/job_routes.rs
+++ b/switchboard/tests/job_routes.rs
@@ -31,6 +31,7 @@ use treadmill_rs::image::Digest;
 /// member, so she may file a job under it.
 const ADMINS_GROUP_ID: Uuid = Uuid::from_u128(1);
 use treadmill_switchboard::config::LogStreamingConfig;
+use treadmill_switchboard::events::EventBus;
 use treadmill_switchboard::log_streaming::{LogStreamProvisioner, LogStreaming, ProvisionError};
 use treadmill_switchboard::registry::OciRegistryClient;
 use treadmill_switchboard::serve::AppState;
@@ -84,6 +85,7 @@ fn streaming_enabled_state_with(pool: PgPool, provisioner: Arc<NoopProvisioner>)
         test_config_mock(),
         Arc::new(OciRegistryClient::new()),
         Some(test_log_streaming(provisioner)),
+        EventBus::default(),
     )
 }
 

--- a/switchboard/tests/notify_triggers.rs
+++ b/switchboard/tests/notify_triggers.rs
@@ -186,6 +186,14 @@ async fn jobs_changes_emit_routing_keys(pool: PgPool) {
     expected.sort();
     assert_eq!(key_values(&event, "dispatched_on_host_id"), expected);
 
+    // A write that changes nothing is silent (proven by the delete event
+    // arriving next).
+    sqlx::query("update tml_switchboard.jobs set job_state = job_state where job_id = $1")
+        .bind(job)
+        .execute(&pool)
+        .await
+        .unwrap();
+
     // Delete: keys come from the OLD row.
     sqlx::query("delete from tml_switchboard.jobs where job_id = $1")
         .bind(job)
@@ -219,6 +227,14 @@ async fn host_heartbeats_stay_silent(pool: PgPool) {
         .await
         .unwrap();
     sqlx::query("update tml_switchboard.hosts set last_seen_at = null where host_id = $1")
+        .bind(host)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // A statement touching a notifying column without changing the row is
+    // equally silent.
+    sqlx::query("update tml_switchboard.hosts set tags = tags where host_id = $1")
         .bind(host)
         .execute(&pool)
         .await

--- a/switchboard/tests/notify_triggers.rs
+++ b/switchboard/tests/notify_triggers.rs
@@ -1,0 +1,287 @@
+//! DB-backed tests for the `tml_events` change-notification triggers
+//! (`notify_change()`, `jobs_notify`, `hosts_notify` — see the CHANGE
+//! NOTIFICATIONS section of SCHEMA.sql for the payload contract).
+//!
+//! Each test opens a raw `PgListener` on the per-test database and asserts on
+//! the exact sequence of received payloads: single-statement writes commit in
+//! order, so the notification order is deterministic. "Emits nothing" is
+//! proven by a marker write whose event must be the next one received.
+
+use std::time::Duration;
+
+use serde_json::Value;
+use sqlx::PgPool;
+use sqlx::postgres::PgListener;
+use treadmill_rs::image::{Digest, media_types};
+use treadmill_switchboard::sql;
+use uuid::Uuid;
+
+async fn listen(pool: &PgPool) -> PgListener {
+    let mut listener = PgListener::connect_with(pool).await.unwrap();
+    listener.listen("tml_events").await.unwrap();
+    listener
+}
+
+async fn next_event(listener: &mut PgListener) -> Value {
+    let notification = tokio::time::timeout(Duration::from_secs(10), listener.recv())
+        .await
+        .expect("timed out waiting for a tml_events notification")
+        .expect("listener connection failed");
+    serde_json::from_str(notification.payload()).expect("payload must be JSON")
+}
+
+/// The values of one routing key, sorted for order-insensitive comparison.
+fn key_values(event: &Value, column: &str) -> Vec<String> {
+    let mut values: Vec<String> = event["keys"][column]
+        .as_array()
+        .unwrap_or_else(|| panic!("no key {column} in {event}"))
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    values.sort();
+    values
+}
+
+async fn insert_user(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query("insert into tml_switchboard.subjects (subject_id, kind) values ($1, 'user')")
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("insert into tml_switchboard.users (subject_id, username) values ($1, $2)")
+        .bind(id)
+        .bind(format!("user-{id}"))
+        .execute(pool)
+        .await
+        .unwrap();
+    id
+}
+
+async fn insert_token(pool: &PgPool, user_id: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let mut token = vec![0u8; 32];
+    token[..16].copy_from_slice(id.as_bytes());
+    sqlx::query(
+        "insert into tml_switchboard.api_tokens \
+         (token_id, token, user_id, revoked, created_at, expires_at) \
+         values ($1, $2, $3, null, now(), now() + interval '1 day')",
+    )
+    .bind(id)
+    .bind(token)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn insert_host(pool: &PgPool, owner: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    let mut auth_token = vec![0u8; 32];
+    auth_token[..16].copy_from_slice(id.as_bytes());
+    sqlx::query(
+        "insert into tml_switchboard.hosts \
+         (host_id, name, auth_token, tags, ssh_endpoints, worker_instance_id, owner_id) \
+         values ($1, $2, $3, '{}', '{}'::tml_switchboard.ssh_endpoint[], 0, $4)",
+    )
+    .bind(id)
+    .bind(format!("host-{id}"))
+    .bind(auth_token)
+    .bind(owner)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn insert_image(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    let digest = {
+        let mut seed = [0u8; 32];
+        seed[..16].copy_from_slice(id.as_bytes());
+        Digest::from_sha256(seed)
+    };
+    sql::image::insert(
+        pool,
+        id,
+        &digest.encoded(),
+        media_types::IMAGE_ARTIFACT_TYPE,
+        None,
+    )
+    .await
+    .unwrap();
+    id
+}
+
+async fn insert_job(pool: &PgPool, owner: Uuid, token: Uuid, image: Uuid) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "insert into tml_switchboard.jobs \
+         (job_id, owner_id, image_id, ssh_keys, restart_policy, enqueued_by_token_id, \
+          host_tag_requirements, job_timeout, job_state, queued_at) \
+         values ($1, $2, $3, '{}', row(0)::tml_switchboard.restart_policy, $4, '{}', \
+                 interval '1 hour', 'queued', now())",
+    )
+    .bind(id)
+    .bind(owner)
+    .bind(image)
+    .bind(token)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+#[sqlx::test]
+#[ignore = "needs Postgres; run via `cargo nextest run --run-ignored only`"]
+async fn jobs_changes_emit_routing_keys(pool: PgPool) {
+    let user = insert_user(&pool).await;
+    let token = insert_token(&pool, user).await;
+    let image = insert_image(&pool).await;
+
+    let mut listener = listen(&pool).await;
+
+    let host_a = insert_host(&pool, user).await;
+    let host_b = insert_host(&pool, user).await;
+    for expected in [host_a, host_b] {
+        let event = next_event(&mut listener).await;
+        assert_eq!(event["table"], "hosts");
+        assert_eq!(key_values(&event, "host_id"), vec![expected.to_string()]);
+    }
+
+    // Insert: the pk is a key; the NULL dispatched_on_host_id is omitted.
+    let job = insert_job(&pool, user, token, image).await;
+    let event = next_event(&mut listener).await;
+    assert_eq!(event["table"], "jobs");
+    assert_eq!(key_values(&event, "job_id"), vec![job.to_string()]);
+    assert!(event["keys"].get("dispatched_on_host_id").is_none());
+
+    // Assignment: the new host id appears as a routing key.
+    sqlx::query(
+        "update tml_switchboard.jobs \
+         set job_state = 'assigned', dispatched_on_host_id = $2 where job_id = $1",
+    )
+    .bind(job)
+    .bind(host_a)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let event = next_event(&mut listener).await;
+    assert_eq!(
+        key_values(&event, "dispatched_on_host_id"),
+        vec![host_a.to_string()]
+    );
+
+    // Changing a routing-key column wakes both the old and the new scope.
+    sqlx::query("update tml_switchboard.jobs set dispatched_on_host_id = $2 where job_id = $1")
+        .bind(job)
+        .bind(host_b)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let event = next_event(&mut listener).await;
+    let mut expected = vec![host_a.to_string(), host_b.to_string()];
+    expected.sort();
+    assert_eq!(key_values(&event, "dispatched_on_host_id"), expected);
+
+    // Delete: keys come from the OLD row.
+    sqlx::query("delete from tml_switchboard.jobs where job_id = $1")
+        .bind(job)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let event = next_event(&mut listener).await;
+    assert_eq!(event["table"], "jobs");
+    assert_eq!(key_values(&event, "job_id"), vec![job.to_string()]);
+    assert_eq!(
+        key_values(&event, "dispatched_on_host_id"),
+        vec![host_b.to_string()]
+    );
+}
+
+#[sqlx::test]
+#[ignore = "needs Postgres; run via `cargo nextest run --run-ignored only`"]
+async fn host_heartbeats_stay_silent(pool: PgPool) {
+    let user = insert_user(&pool).await;
+    let mut listener = listen(&pool).await;
+
+    let host = insert_host(&pool, user).await;
+    let event = next_event(&mut listener).await;
+    assert_eq!(event["table"], "hosts");
+    assert_eq!(key_values(&event, "host_id"), vec![host.to_string()]);
+
+    // Heartbeat refresh and clean-disconnect (`last_seen_at` only): no events.
+    sqlx::query("update tml_switchboard.hosts set last_seen_at = now() where host_id = $1")
+        .bind(host)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("update tml_switchboard.hosts set last_seen_at = null where host_id = $1")
+        .bind(host)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Worker takeover (connect edge) does notify — and being the very next
+    // event received, it proves the heartbeat writes above emitted nothing.
+    sqlx::query(
+        "update tml_switchboard.hosts \
+         set worker_instance_id = worker_instance_id + 1 where host_id = $1",
+    )
+    .bind(host)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let event = next_event(&mut listener).await;
+    assert_eq!(event["table"], "hosts");
+    assert_eq!(key_values(&event, "host_id"), vec![host.to_string()]);
+}
+
+#[sqlx::test]
+#[ignore = "needs Postgres; run via `cargo nextest run --run-ignored only`"]
+async fn bulk_update_folds_into_one_keyless_event(pool: PgPool) {
+    let user = insert_user(&pool).await;
+    let hosts = [
+        insert_host(&pool, user).await,
+        insert_host(&pool, user).await,
+        insert_host(&pool, user).await,
+        insert_host(&pool, user).await,
+    ];
+
+    let mut listener = listen(&pool).await;
+
+    let mut txn = pool.begin().await.unwrap();
+    sqlx::query("set local tml_switchboard.notify_row_limit = '2'")
+        .execute(&mut *txn)
+        .await
+        .unwrap();
+    sqlx::query("update tml_switchboard.hosts set tags = array['bulk']")
+        .execute(&mut *txn)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // Rows up to the limit emit per-row events; everything beyond folds into
+    // identical keyless payloads that Postgres dedups to a single delivery.
+    for _ in 0..2 {
+        let event = next_event(&mut listener).await;
+        assert_eq!(event["table"], "hosts");
+        let values = key_values(&event, "host_id");
+        assert_eq!(values.len(), 1);
+        assert!(hosts.iter().any(|h| h.to_string() == values[0]));
+    }
+    let event = next_event(&mut listener).await;
+    assert_eq!(event["table"], "hosts");
+    assert!(event.get("keys").is_none());
+
+    // A marker write must be the very next event: the bulk transaction
+    // produced nothing further.
+    sqlx::query("update tml_switchboard.hosts set tags = array['marker'] where host_id = $1")
+        .bind(hosts[0])
+        .execute(&pool)
+        .await
+        .unwrap();
+    let event = next_event(&mut listener).await;
+    assert_eq!(key_values(&event, "host_id"), vec![hosts[0].to_string()]);
+}

--- a/switchboard/tests/notify_triggers.rs
+++ b/switchboard/tests/notify_triggers.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 use sqlx::PgPool;
 use sqlx::postgres::PgListener;
 use treadmill_rs::image::{Digest, media_types};
+use treadmill_switchboard::events::{EventBus, EventFilter};
 use treadmill_switchboard::sql;
 use uuid::Uuid;
 
@@ -236,6 +237,45 @@ async fn host_heartbeats_stay_silent(pool: PgPool) {
     let event = next_event(&mut listener).await;
     assert_eq!(event["table"], "hosts");
     assert_eq!(key_values(&event, "host_id"), vec![host.to_string()]);
+}
+
+#[sqlx::test]
+#[ignore = "needs Postgres; run via `cargo nextest run --run-ignored only`"]
+async fn event_bus_listener_delivers_wakes(pool: PgPool) {
+    let user = insert_user(&pool).await;
+    let host = insert_host(&pool, user).await;
+
+    let bus = EventBus::default();
+    tokio::spawn(bus.listener(pool.clone()));
+    let mut subscription = bus.subscribe(EventFilter {
+        table: "hosts",
+        key: Some(("host_id", host)),
+    });
+    subscription.changed().await;
+
+    // The listener may not have connected yet when the first write commits (a
+    // wake missed for that reason is what consumers' timers cover); retry the
+    // write until a wake arrives.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        sqlx::query(
+            "update tml_switchboard.hosts set tags = array[md5(random()::text)] where host_id = $1",
+        )
+        .bind(host)
+        .execute(&pool)
+        .await
+        .unwrap();
+        if tokio::time::timeout(Duration::from_millis(500), subscription.changed())
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "no wake delivered through the event bus"
+        );
+    }
 }
 
 #[sqlx::test]


### PR DESCRIPTION
This also prepares the switchboard for SSE/fetch-style event streaming in the frontend.
