### PR TITLE
switchboard: add `swx manage` commands

### DIFF
--- a/.sqlx/query-5160fac8a06aafb745f71f564fae37a9159d6ce47d70543efde33dec2454ed20.json
+++ b/.sqlx/query-5160fac8a06aafb745f71f564fae37a9159d6ce47d70543efde33dec2454ed20.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "delete from tml_switchboard.group_members where group_id = $1 and member_id = $2 and source = 'manual';",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5160fac8a06aafb745f71f564fae37a9159d6ce47d70543efde33dec2454ed20"
+}

--- a/.sqlx/query-6186a15cc2734ca6cdbc9cc9e3a91dfa79c79f0e7c34d0fef96491f4e458fd60.json
+++ b/.sqlx/query-6186a15cc2734ca6cdbc9cc9e3a91dfa79c79f0e7c34d0fef96491f4e458fd60.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select distinct u.subject_id, u.name from tml_switchboard.users u join tml_switchboard.user_identities i on i.user_id = u.subject_id where lower(i.provider_login) = lower($1);",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "subject_id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.users",
+            "name": "subject_id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.users",
+            "name": "name"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "6186a15cc2734ca6cdbc9cc9e3a91dfa79c79f0e7c34d0fef96491f4e458fd60"
+}

--- a/.sqlx/query-7f3a8626961bb8deb050b3d5fc3823eb9d5e580d519719f7abab7541d522679f.json
+++ b/.sqlx/query-7f3a8626961bb8deb050b3d5fc3823eb9d5e580d519719f7abab7541d522679f.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select exists (\n                select 1 from tml_switchboard.login_allowlist\n                where provider = $1 and kind = $2 and external_id = $3\n            ) as \"present!\";",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "present!",
+        "type_info": "Bool",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "7f3a8626961bb8deb050b3d5fc3823eb9d5e580d519719f7abab7541d522679f"
+}

--- a/.sqlx/query-808b49c553758b2d77dab7683da51c7e793fde39cb5e855bc50bb5669405e536.json
+++ b/.sqlx/query-808b49c553758b2d77dab7683da51c7e793fde39cb5e855bc50bb5669405e536.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select subject_id, name from tml_switchboard.users where subject_id = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "subject_id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.users",
+            "name": "subject_id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.users",
+            "name": "name"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "808b49c553758b2d77dab7683da51c7e793fde39cb5e855bc50bb5669405e536"
+}

--- a/.sqlx/query-85a02fd990da1c2a800c6fd85c767891d2ac47f4dde28db38989f8c3b9f3a30b.json
+++ b/.sqlx/query-85a02fd990da1c2a800c6fd85c767891d2ac47f4dde28db38989f8c3b9f3a30b.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "delete from tml_switchboard.login_allowlist where provider = $1 and kind = $2 and external_id = $3;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "85a02fd990da1c2a800c6fd85c767891d2ac47f4dde28db38989f8c3b9f3a30b"
+}

--- a/.sqlx/query-9aa75d3a7f425c3d0364bac99838ad6099a37a4047297b8d266f5a07ad1ad733.json
+++ b/.sqlx/query-9aa75d3a7f425c3d0364bac99838ad6099a37a4047297b8d266f5a07ad1ad733.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select exists (\n                select 1 from tml_switchboard.group_members\n                where group_id = $1 and member_id = $2 and source = 'manual'\n            ) as \"member!\";",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "member!",
+        "type_info": "Bool",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9aa75d3a7f425c3d0364bac99838ad6099a37a4047297b8d266f5a07ad1ad733"
+}

--- a/.sqlx/query-b05fe2951084dda4fad4bb87524a9dfa8bb6d1b1ec0512fd56648a78182ae5d5.json
+++ b/.sqlx/query-b05fe2951084dda4fad4bb87524a9dfa8bb6d1b1ec0512fd56648a78182ae5d5.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into tml_switchboard.group_auto_sources (group_id, provider, external_id, external_name, membership_via) values ($1, 'github', $2, $3, 'github_org');",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b05fe2951084dda4fad4bb87524a9dfa8bb6d1b1ec0512fd56648a78182ae5d5"
+}

--- a/.sqlx/query-b84c41f0c134f9810c37242e9c44aaa0b5575aac8b4f9b4f48d2d42458b3cdfe.json
+++ b/.sqlx/query-b84c41f0c134f9810c37242e9c44aaa0b5575aac8b4f9b4f48d2d42458b3cdfe.json
@@ -1,0 +1,74 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select provider, kind, external_id, comment, added_at from tml_switchboard.login_allowlist order by provider, kind, external_id;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "provider",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.login_allowlist",
+            "name": "provider"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "kind",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.login_allowlist",
+            "name": "kind"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "external_id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.login_allowlist",
+            "name": "external_id"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "comment",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.login_allowlist",
+            "name": "comment"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "added_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "tml_switchboard.login_allowlist",
+            "name": "added_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "b84c41f0c134f9810c37242e9c44aaa0b5575aac8b4f9b4f48d2d42458b3cdfe"
+}

--- a/.sqlx/query-da9ad66fdfbd355789549542b86e38439d3b1218e76835dae600e202aa3fdec5.json
+++ b/.sqlx/query-da9ad66fdfbd355789549542b86e38439d3b1218e76835dae600e202aa3fdec5.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into tml_switchboard.group_members (group_id, member_id, source) values ($1, $2, 'manual') on conflict do nothing;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "da9ad66fdfbd355789549542b86e38439d3b1218e76835dae600e202aa3fdec5"
+}

--- a/.sqlx/query-edaf33ed6c62c8c754d3dd83c5cbebb0f6dc6c8cb46585aaff5bc31487ff1dc8.json
+++ b/.sqlx/query-edaf33ed6c62c8c754d3dd83c5cbebb0f6dc6c8cb46585aaff5bc31487ff1dc8.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into tml_switchboard.groups (subject_id, name) values ($1, $2);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "edaf33ed6c62c8c754d3dd83c5cbebb0f6dc6c8cb46585aaff5bc31487ff1dc8"
+}

--- a/.sqlx/query-ef5d3a42c73940c63275dfbebf7dbdca578b98a9931714112d49daf2ad1d936f.json
+++ b/.sqlx/query-ef5d3a42c73940c63275dfbebf7dbdca578b98a9931714112d49daf2ad1d936f.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into tml_switchboard.login_allowlist (provider, kind, external_id, comment) values ($1, $2, $3, $4) on conflict (provider, kind, external_id) do nothing;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ef5d3a42c73940c63275dfbebf7dbdca578b98a9931714112d49daf2ad1d936f"
+}

--- a/.sqlx/query-fae9638887cde310e456ab9d766b2b9e661d98ab8795866fe28e2960d552ac56.json
+++ b/.sqlx/query-fae9638887cde310e456ab9d766b2b9e661d98ab8795866fe28e2960d552ac56.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "insert into tml_switchboard.subjects (subject_id, kind) values ($1, 'group');",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fae9638887cde310e456ab9d766b2b9e661d98ab8795866fe28e2960d552ac56"
+}

--- a/switchboard/Cargo.toml
+++ b/switchboard/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "swx"
+path = "src/main.rs"
+
 [dependencies]
 treadmill-rs = { workspace = true }
 
@@ -105,8 +109,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 humantime-serde = { workspace = true }
-# OpenAPI snapshot is emitted as YAML (api-spec/openapi.yaml); used by the
-# dump-openapi bin and the drift-guard test.
+# OpenAPI snapshot emitted as YAML (api-spec/openapi.yaml)
 serde_norway = "0.9"
 # Configuration deserialization
 toml = { workspace = true }

--- a/switchboard/src/audit/events.rs
+++ b/switchboard/src/audit/events.rs
@@ -286,6 +286,51 @@ define_event! {
 }
 
 define_event! {
+    /// Global admin authority (direct `manual` membership in the `admins`
+    /// group) was granted or revoked by an operator through the `manage` CLI.
+    /// Attributed to the system actor -- the CLI runs against the database
+    /// without an authenticated subject.
+    AdminAuthorityChanged v1 {
+        actor: Subject,
+        user: Subject @ view(SelfAccess),
+        granted: bool,
+    }
+    event_type = "admin_authority_changed";
+    render = "admin authority granted = {granted}";
+}
+
+define_event! {
+    /// A group was created through the `manage` CLI, optionally bound in the
+    /// same transaction to an external auto-membership source (see
+    /// `group_auto_sources`). Attributed to the system actor.
+    GroupCreated v1 {
+        actor: Subject,
+        group: Subject @ view(OperatorOnly),
+        name: String,
+        auto_source_provider: Option<String>,
+        auto_source_external_id: Option<String>,
+    }
+    event_type = "group_created";
+    render = "created group {name}";
+}
+
+define_event! {
+    /// An entry was added to or removed from the `login_allowlist` consulted by
+    /// the admission gate ([`crate::auth::admission`]), through the `manage`
+    /// CLI. Operator-only: the entry names an external identity that may have
+    /// no local account, so there is no user relation to hang it off.
+    LoginAllowlistChanged v1 {
+        actor: Subject,
+        provider: String,
+        kind: String,
+        external_id: String,
+        added: bool,
+    }
+    event_type = "login_allowlist_changed";
+    render = "login allowlist {kind} {external_id} ({provider}) added = {added}";
+}
+
+define_event! {
     /// A user enqueued a new job (`POST /jobs`). Related to the job with the
     /// `read` policy, so it surfaces in the job's event feed for anyone who can
     /// read the job (its owner, a read-grantee, or an admin).

--- a/switchboard/src/bin/dump-openapi.rs
+++ b/switchboard/src/bin/dump-openapi.rs
@@ -1,8 +1,0 @@
-use treadmill_switchboard::routes::openapi_spec;
-
-fn main() {
-    let api = openapi_spec();
-
-    // YAML: matches the committed snapshot format (api-spec/openapi.yaml).
-    print!("{}", serde_norway::to_string(&api).unwrap());
-}

--- a/switchboard/src/config.rs
+++ b/switchboard/src/config.rs
@@ -146,7 +146,7 @@ fn default_github_auth_url() -> String {
 fn default_github_token_url() -> String {
     "https://github.com/login/oauth/access_token".to_string()
 }
-fn default_github_api_base_url() -> String {
+pub(crate) fn default_github_api_base_url() -> String {
     "https://api.github.com".to_string()
 }
 

--- a/switchboard/src/lib.rs
+++ b/switchboard/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod events;
 pub(crate) mod http_error;
 pub mod log_streaming;
+pub mod manage;
 pub mod matcher;
 pub mod registry;
 pub mod routes;

--- a/switchboard/src/main.rs
+++ b/switchboard/src/main.rs
@@ -1,7 +1,7 @@
 //! Switchboard runner. Run as a command-line tool.
 
 use clap::{Parser, Subcommand};
-use treadmill_switchboard::serve::ServeCommand;
+use treadmill_switchboard::{manage::ManageCommand, routes::openapi_spec, serve::ServeCommand};
 
 #[derive(Debug, Parser)]
 #[command(version, about)]
@@ -9,15 +9,24 @@ pub struct Args {
     #[command(subcommand)]
     pub command: Command,
 }
+
 #[derive(Debug, Subcommand)]
 #[command(about)]
 pub enum Command {
     Serve(ServeCommand),
+    Manage(ManageCommand),
+    GenerateOpenAPISpec,
 }
+
 impl Command {
     async fn run(self) -> anyhow::Result<()> {
         match self {
             Command::Serve(serve_cmd) => treadmill_switchboard::serve::serve(serve_cmd).await,
+            Command::Manage(manage_cmd) => manage_cmd.run().await,
+            Command::GenerateOpenAPISpec => {
+                println!("{}", serde_norway::to_string(&openapi_spec()).unwrap());
+                Ok(())
+            }
         }
     }
 }
@@ -27,6 +36,6 @@ async fn main() {
     let cli_args = Args::parse();
 
     if let Err(e) = cli_args.command.run().await {
-        eprintln!("Failed to run `serve` command:\n{e:?}");
+        eprintln!("Failed to run command:\n{e:?}");
     }
 }

--- a/switchboard/src/manage.rs
+++ b/switchboard/src/manage.rs
@@ -1,0 +1,590 @@
+//! Admin management commands for the Treadmill Switchboard.
+//!
+//! These commands are useful for managing a switchboard instance, such as for
+//! boostrapping admin users, or adding users/groups to the allow-list.
+//!
+//! They talk to the database directly, with no authenticated subject, so every
+//! write rides the audit chokepoint ([`audit::transition`]) attributed to the
+//! system actor, and asks for interactive confirmation first.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, bail};
+use sqlx::{PgConnection, PgPool};
+use uuid::Uuid;
+
+use crate::audit::model::Subject as AuditSubject;
+use crate::audit::{self, SYSTEM_ACTOR_ID, Transition, WriteToken, events};
+use crate::auth::engine::ADMINS_GROUP_ID;
+
+#[derive(clap::Args, Debug)]
+pub struct ManageCommand {
+    #[arg(short = 'c', long = "config", env = "TML_CFG_FILE")]
+    config: Option<PathBuf>,
+    #[command(subcommand)]
+    subcommand: ManageSubcommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum ManageSubcommand {
+    /// Grant or revoke global admin authority.
+    #[command(subcommand)]
+    Admin(AdminSubcommand),
+    /// Inspect and edit the login allow-list consulted for new registrations.
+    #[command(subcommand)]
+    Allowlist(AllowlistSubcommand),
+    /// Create groups.
+    #[command(subcommand)]
+    Group(GroupSubcommand),
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum AdminSubcommand {
+    /// Add a user to the `admins` group.
+    Grant { user: UserRef },
+    /// Remove a user's direct membership in the `admins` group.
+    Revoke { user: UserRef },
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum AllowlistSubcommand {
+    /// List every allow-list entry.
+    List,
+    /// Allow an external user or org to register.
+    Add {
+        kind: AllowlistKind,
+        /// The provider's stable id, or (for GitHub) a login handle, which is
+        /// resolved to the id it currently names. Entries always key on the id:
+        /// a handle can be renamed away and re-registered by someone else.
+        external_id: String,
+        #[arg(long, default_value = "github")]
+        provider: String,
+        /// Free-form note recorded alongside the entry (e.g. who asked for it).
+        /// Defaults to the handle the entry was added by.
+        #[arg(long)]
+        comment: Option<String>,
+    },
+    /// Remove an allow-list entry. Already-registered users keep their account.
+    Remove {
+        kind: AllowlistKind,
+        /// The provider's stable id, or (for GitHub) a login handle. A handle
+        /// resolves to the id it names *today*, which is not necessarily the
+        /// one on the entry -- check `allowlist list` if in doubt.
+        external_id: String,
+        #[arg(long, default_value = "github")]
+        provider: String,
+    },
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum GroupSubcommand {
+    /// Create an empty group, optionally auto-synced from a GitHub org.
+    Create {
+        name: String,
+        /// The org's stable numeric id, or its login handle (resolved to the
+        /// id). Members of this org are added to the group by the auto-group
+        /// reconciler as they log in.
+        #[arg(long)]
+        github_org: Option<String>,
+        /// The org's login handle, recorded for display only. Defaults to the
+        /// handle the id resolves to.
+        #[arg(long, requires = "github_org")]
+        github_org_name: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum AllowlistKind {
+    User,
+    Org,
+}
+
+impl AllowlistKind {
+    /// The value stored in `login_allowlist.kind`.
+    fn as_str(self) -> &'static str {
+        match self {
+            AllowlistKind::User => "user",
+            AllowlistKind::Org => "org",
+        }
+    }
+}
+
+/// How a user is named on the command line: either their internal subject id,
+/// or a provider login handle (which must resolve to exactly one account).
+#[derive(Debug, Clone)]
+pub enum UserRef {
+    Id(Uuid),
+    Login(String),
+}
+
+impl std::str::FromStr for UserRef {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match Uuid::parse_str(s) {
+            Ok(id) => UserRef::Id(id),
+            Err(_) => UserRef::Login(s.to_string()),
+        })
+    }
+}
+
+impl ManageCommand {
+    pub async fn run(self) -> anyhow::Result<()> {
+        let config = crate::config::load_configuration(self.config.as_deref())?;
+        let pool = crate::serve::pg_pool_from_config(&config.database)
+            .await
+            .context("failed to connect to database")?;
+
+        // Handle lookups go to the same API the login flow uses, so a GitHub
+        // Enterprise deployment resolves against its own instance.
+        let github_api = match &config.oauth.github {
+            Some(gh) => gh.api_base_url.trim_end_matches('/').to_string(),
+            None => crate::config::default_github_api_base_url(),
+        };
+
+        match self.subcommand {
+            ManageSubcommand::Admin(cmd) => cmd.run(&pool).await,
+            ManageSubcommand::Allowlist(cmd) => cmd.run(&pool, &github_api).await,
+            ManageSubcommand::Group(cmd) => cmd.run(&pool, &github_api).await,
+        }
+    }
+}
+
+impl AdminSubcommand {
+    async fn run(self, pool: &PgPool) -> anyhow::Result<()> {
+        let (user, granted) = match self {
+            AdminSubcommand::Grant { user } => (user, true),
+            AdminSubcommand::Revoke { user } => (user, false),
+        };
+
+        let (user_id, name) = resolve_user(pool, &user).await?;
+
+        // Only direct `manual` membership is ours to change: a user may also
+        // hold admin authority transitively (through a nested or auto-synced
+        // group), which revoking here does not take away.
+        let member = sqlx::query_scalar!(
+            r#"select exists (
+                select 1 from tml_switchboard.group_members
+                where group_id = $1 and member_id = $2 and source = 'manual'
+            ) as "member!";"#,
+            ADMINS_GROUP_ID,
+            user_id,
+        )
+        .fetch_one(pool)
+        .await?;
+
+        if member == granted {
+            println!(
+                "{name} ({user_id}) is already {}an admin; nothing to do",
+                if granted { "" } else { "not " }
+            );
+            return Ok(());
+        }
+
+        let verb = if granted { "GRANT" } else { "REVOKE" };
+        if !confirm(&format!("{verb} admin authority for {name} ({user_id})?"))? {
+            bail!("aborted");
+        }
+
+        let mut txn = pool.begin().await?;
+        audit::transition(&mut txn, SetAdmin { user_id, granted }).await?;
+        txn.commit().await?;
+
+        println!("done");
+        Ok(())
+    }
+}
+
+impl AllowlistSubcommand {
+    async fn run(self, pool: &PgPool, github_api: &str) -> anyhow::Result<()> {
+        let (provider, kind, external_id, comment, added) = match self {
+            AllowlistSubcommand::List => return list_allowlist(pool).await,
+            AllowlistSubcommand::Add {
+                kind,
+                external_id,
+                provider,
+                comment,
+            } => (provider, kind, external_id, comment, true),
+            AllowlistSubcommand::Remove {
+                kind,
+                external_id,
+                provider,
+            } => (provider, kind, external_id, None, false),
+        };
+
+        let kind_str = kind.as_str();
+
+        // The table keys on the provider's stable id; accept the handle too.
+        let (external_id, handle) = match provider.as_str() {
+            "github" => resolve_github(github_api, &external_id).await?,
+            _ => (external_id, None),
+        };
+        let display = match &handle {
+            Some(h) => format!("{external_id} ({h})"),
+            None => external_id.clone(),
+        };
+        // With no note of its own, an entry records the handle it was added
+        // by -- the id alone tells a later reader nothing.
+        let comment = comment.or(handle);
+
+        let present = sqlx::query_scalar!(
+            r#"select exists (
+                select 1 from tml_switchboard.login_allowlist
+                where provider = $1 and kind = $2 and external_id = $3
+            ) as "present!";"#,
+            provider,
+            kind_str,
+            external_id,
+        )
+        .fetch_one(pool)
+        .await?;
+
+        if present == added {
+            println!(
+                "{provider} {kind_str} {display} is already {}allowed; nothing to do",
+                if added { "" } else { "not " }
+            );
+            return Ok(());
+        }
+
+        let verb = if added { "ALLOW" } else { "DISALLOW" };
+        if !confirm(&format!(
+            "{verb} registration for {provider} {kind_str} {display}?"
+        ))? {
+            bail!("aborted");
+        }
+
+        let mut txn = pool.begin().await?;
+        audit::transition(
+            &mut txn,
+            SetAllowlistEntry {
+                provider,
+                kind,
+                external_id,
+                comment,
+                added,
+            },
+        )
+        .await?;
+        txn.commit().await?;
+
+        println!("done");
+        Ok(())
+    }
+}
+
+async fn list_allowlist(pool: &PgPool) -> anyhow::Result<()> {
+    let entries = sqlx::query!(
+        "select provider, kind, external_id, comment, added_at \
+         from tml_switchboard.login_allowlist \
+         order by provider, kind, external_id;",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let n = entries.len();
+    println!("{n} allow-list entr{}", if n == 1 { "y" } else { "ies" });
+    for e in &entries {
+        println!(
+            "{:<10} {:<5} {:<24} {}  {}",
+            e.provider,
+            e.kind,
+            e.external_id,
+            e.added_at.format("%Y-%m-%d"),
+            e.comment.as_deref().unwrap_or(""),
+        );
+    }
+    Ok(())
+}
+
+impl GroupSubcommand {
+    async fn run(self, pool: &PgPool, github_api: &str) -> anyhow::Result<()> {
+        let GroupSubcommand::Create {
+            name,
+            github_org,
+            github_org_name,
+        } = self;
+
+        // The binding keys on the org's stable id; accept its handle too.
+        let (github_org, github_org_name) = match github_org {
+            Some(org) => {
+                let (id, handle) = resolve_github(github_api, &org).await?;
+                (Some(id), github_org_name.or(handle))
+            }
+            None => (None, None),
+        };
+
+        let bound_to = match (&github_org, &github_org_name) {
+            (Some(id), Some(handle)) => format!(", auto-synced from github org {id} ({handle})"),
+            (Some(id), None) => format!(", auto-synced from github org {id}"),
+            (None, _) => String::new(),
+        };
+        if !confirm(&format!("CREATE group {name}{bound_to}?"))? {
+            bail!("aborted");
+        }
+
+        let mut txn = pool.begin().await?;
+        let group_id = audit::transition(
+            &mut txn,
+            CreateGroup {
+                name,
+                github_org,
+                github_org_name,
+            },
+        )
+        .await?;
+        txn.commit().await?;
+
+        println!("created group {group_id}");
+        Ok(())
+    }
+}
+
+/// Look up the subject id and display name of the user named on the command
+/// line. A login handle must match exactly one account across all providers.
+async fn resolve_user(pool: &PgPool, user: &UserRef) -> anyhow::Result<(Uuid, String)> {
+    match user {
+        UserRef::Id(id) => sqlx::query!(
+            "select subject_id, name from tml_switchboard.users where subject_id = $1;",
+            id,
+        )
+        .fetch_optional(pool)
+        .await?
+        .map(|r| (r.subject_id, r.name))
+        .with_context(|| format!("no user with subject id {id}")),
+
+        UserRef::Login(login) => {
+            let mut rows = sqlx::query!(
+                "select distinct u.subject_id, u.name \
+                 from tml_switchboard.users u \
+                 join tml_switchboard.user_identities i on i.user_id = u.subject_id \
+                 where lower(i.provider_login) = lower($1);",
+                login,
+            )
+            .fetch_all(pool)
+            .await?;
+
+            match rows.len() {
+                0 => bail!("no user with provider login {login}"),
+                1 => {
+                    let r = rows.remove(0);
+                    Ok((r.subject_id, r.name))
+                }
+                n => bail!("{login} matches {n} users; name one by subject id instead"),
+            }
+        }
+    }
+}
+
+/// Resolve a GitHub user or org handle to the stable numeric id everything is
+/// keyed on, returning `(id, handle)`. An all-digits argument is already an id
+/// and is taken as-is (with no handle to report), so both forms work on the
+/// command line. Handles are renameable and are only ever carried alongside
+/// the id, for display.
+async fn resolve_github(
+    api_base_url: &str,
+    name: &str,
+) -> anyhow::Result<(String, Option<String>)> {
+    if name.chars().all(|c| c.is_ascii_digit()) {
+        return Ok((name.to_string(), None));
+    }
+
+    #[derive(serde::Deserialize)]
+    struct GhAccount {
+        id: i64,
+        login: String,
+    }
+
+    // `/users/{handle}` resolves organizations too (as `type: Organization`).
+    let url = format!("{api_base_url}/users/{name}");
+    let account: GhAccount = reqwest::Client::new()
+        .get(&url)
+        .header("User-Agent", "treadmill-switchboard")
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("no such GitHub user or org: {name}"))?
+        .json()
+        .await
+        .with_context(|| format!("GET {url}: decoding response"))?;
+
+    Ok((account.id.to_string(), Some(account.login)))
+}
+
+/// Ask on the terminal before a write proceeds. Anything but a literal `yes`
+/// (including a closed stdin, e.g. when run non-interactively) declines.
+fn confirm(prompt: &str) -> anyhow::Result<bool> {
+    print!("{prompt} [yes/no] ");
+    io::stdout().flush()?;
+
+    let mut line = String::new();
+    if io::stdin().read_line(&mut line)? == 0 {
+        println!();
+        return Ok(false);
+    }
+    Ok(line.trim() == "yes")
+}
+
+/// Add or remove a user's direct `manual` membership in the `admins` group.
+/// Emits [`events::AdminAuthorityChanged`].
+struct SetAdmin {
+    user_id: Uuid,
+    granted: bool,
+}
+
+impl Transition for SetAdmin {
+    type Output = ();
+    type Event = events::AdminAuthorityChanged;
+
+    async fn apply(
+        self,
+        conn: &mut PgConnection,
+        _w: &WriteToken,
+    ) -> Result<(Self::Output, Self::Event), sqlx::Error> {
+        if self.granted {
+            sqlx::query!(
+                "insert into tml_switchboard.group_members (group_id, member_id, source) \
+                 values ($1, $2, 'manual') on conflict do nothing;",
+                ADMINS_GROUP_ID,
+                self.user_id,
+            )
+            .execute(&mut *conn)
+            .await?;
+        } else {
+            sqlx::query!(
+                "delete from tml_switchboard.group_members \
+                 where group_id = $1 and member_id = $2 and source = 'manual';",
+                ADMINS_GROUP_ID,
+                self.user_id,
+            )
+            .execute(&mut *conn)
+            .await?;
+        }
+
+        let event = events::AdminAuthorityChanged {
+            actor: AuditSubject(SYSTEM_ACTOR_ID),
+            user: AuditSubject(self.user_id),
+            granted: self.granted,
+        };
+        Ok(((), event))
+    }
+}
+
+/// Add or remove one `login_allowlist` entry. Emits
+/// [`events::LoginAllowlistChanged`].
+struct SetAllowlistEntry {
+    provider: String,
+    kind: AllowlistKind,
+    external_id: String,
+    comment: Option<String>,
+    added: bool,
+}
+
+impl Transition for SetAllowlistEntry {
+    type Output = bool;
+    type Event = events::LoginAllowlistChanged;
+
+    async fn apply(
+        self,
+        conn: &mut PgConnection,
+        _w: &WriteToken,
+    ) -> Result<(Self::Output, Self::Event), sqlx::Error> {
+        let kind = self.kind.as_str();
+        let changed = if self.added {
+            sqlx::query!(
+                "insert into tml_switchboard.login_allowlist \
+                 (provider, kind, external_id, comment) values ($1, $2, $3, $4) \
+                 on conflict (provider, kind, external_id) do nothing;",
+                self.provider,
+                kind,
+                self.external_id,
+                self.comment,
+            )
+            .execute(&mut *conn)
+            .await?
+        } else {
+            sqlx::query!(
+                "delete from tml_switchboard.login_allowlist \
+                 where provider = $1 and kind = $2 and external_id = $3;",
+                self.provider,
+                kind,
+                self.external_id,
+            )
+            .execute(&mut *conn)
+            .await?
+        }
+        .rows_affected()
+            > 0;
+
+        let event = events::LoginAllowlistChanged {
+            actor: AuditSubject(SYSTEM_ACTOR_ID),
+            provider: self.provider,
+            kind: kind.to_string(),
+            external_id: self.external_id,
+            added: self.added,
+        };
+        Ok((changed, event))
+    }
+}
+
+/// Create an empty group, optionally bound to a GitHub org whose members the
+/// auto-group reconciler folds in. Emits [`events::GroupCreated`].
+struct CreateGroup {
+    name: String,
+    github_org: Option<String>,
+    github_org_name: Option<String>,
+}
+
+impl Transition for CreateGroup {
+    type Output = Uuid;
+    type Event = events::GroupCreated;
+
+    async fn apply(
+        self,
+        conn: &mut PgConnection,
+        _w: &WriteToken,
+    ) -> Result<(Self::Output, Self::Event), sqlx::Error> {
+        // Time-ordered (v7) for primary-key insert locality.
+        let group_id = Uuid::now_v7();
+        sqlx::query!(
+            "insert into tml_switchboard.subjects (subject_id, kind) values ($1, 'group');",
+            group_id,
+        )
+        .execute(&mut *conn)
+        .await?;
+
+        sqlx::query!(
+            "insert into tml_switchboard.groups (subject_id, name) values ($1, $2);",
+            group_id,
+            self.name,
+        )
+        .execute(&mut *conn)
+        .await?;
+
+        if let Some(external_id) = &self.github_org {
+            sqlx::query!(
+                "insert into tml_switchboard.group_auto_sources \
+                 (group_id, provider, external_id, external_name, membership_via) \
+                 values ($1, 'github', $2, $3, 'github_org');",
+                group_id,
+                external_id,
+                self.github_org_name,
+            )
+            .execute(&mut *conn)
+            .await?;
+        }
+
+        let event = events::GroupCreated {
+            actor: AuditSubject(SYSTEM_ACTOR_ID),
+            group: AuditSubject(group_id),
+            name: self.name,
+            auto_source_provider: self.github_org.as_ref().map(|_| "github".to_string()),
+            auto_source_external_id: self.github_org,
+        };
+        Ok((group_id, event))
+    }
+}

--- a/switchboard/src/routes/mod.rs
+++ b/switchboard/src/routes/mod.rs
@@ -610,10 +610,11 @@ fn doc<'a>(
 
 /// Build the OpenAPI document for the client API.
 ///
-/// Shared by the `dump-openapi` binary and the `openapi_spec` drift test so the
-/// two entry points cannot diverge. Registers the bearer security scheme that
-/// authenticated operations reference via the
-/// [`Subject`](crate::auth::Subject) extractor.
+/// Shared by the OpenAPI spec dump and the `openapi_spec` drift test so the two
+/// entry points cannot diverge.
+///
+/// Registers the bearer security scheme that authenticated operations reference
+/// via the [`Subject`](crate::auth::Subject) extractor.
 pub fn openapi_spec() -> aide::openapi::OpenApi {
     use aide::openapi::{Components, Info, OpenApi, ReferenceOr, SecurityScheme, Tag};
 


### PR DESCRIPTION
Adds a `manage` subcommand for operating an instance from the host:
granting/revoking admin authority, editing the login allow-list, and
creating groups (optionally bound to a GitHub org). Every write asks for
interactive confirmation and emits an audit event through the usual
chokepoint.

Co-Authored-By: Claude <noreply@anthropic.com>
